### PR TITLE
:wrench: cleanup: address issues #1-#4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.4
+  rev: v0.14.6
   hooks:
     # Run the linter.
     - id: ruff

--- a/merle/__init__.py
+++ b/merle/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-__version__ = "0.0.1"
+__version__ = "0.0.3"
 
 logging.basicConfig(
     stream=sys.stdout,

--- a/merle/functions.py
+++ b/merle/functions.py
@@ -748,10 +748,6 @@ def prepare_deployment_files(  # noqa: PLR0915, PLR0912
     # Get template directory from installed package
     template_dir = Path(__file__).parent / "templates"
 
-    # Get consuming project root from current working directory
-    # (where the CLI is being run, not the installed package location)
-    consuming_project_root = Path.cwd()
-
     # Prepare replacements
     region = aws_region or REGION
     tags_dict = tags or {}
@@ -879,13 +875,14 @@ def prepare_deployment_files(  # noqa: PLR0915, PLR0912
         ephemeral_storage=ephemeral_storage,
     )
 
-    # Copy pyproject.toml from consuming project (where CLI is run)
-    pyproject_src = consuming_project_root / "pyproject.toml"
-    if pyproject_src.exists():
-        shutil.copy2(pyproject_src, model_cache_dir / "pyproject.toml")
-        logger.info(f"Copied pyproject.toml from consuming project: {consuming_project_root}")
-    else:
-        logger.warning(f"pyproject.toml not found in consuming project: {consuming_project_root}")
+    # Generate a minimal pyproject.toml for the deployment image.
+    # Copying the consumer's pyproject.toml pulled in unrelated deps and failed
+    # when the consumer declared a readme/build backend the image didn't ship.
+    generate_from_template(
+        template_path=template_dir / "pyproject.toml.template",
+        output_path=model_cache_dir / "pyproject.toml",
+        replacements={"PROJECT_NAME": sanitize_for_cloudformation(project_name)},
+    )
 
     # Note: We intentionally do NOT copy uv.lock or merle/ because:
     # 1. The Docker image may use a different architecture than the host

--- a/merle/managers.py
+++ b/merle/managers.py
@@ -11,6 +11,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,24 @@ from merle.functions import (
 from merle.settings import REGION
 
 logger = logging.getLogger(__name__)
+
+
+def _subprocess_env_with_venv_bin(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """
+    Build a subprocess environment where sys.executable's bin dir is on PATH.
+
+    When merle is invoked via a fully-qualified venv path (e.g.
+    `/tmp/venv/bin/merle`), the child process inherits the parent's PATH, which
+    may not include the venv's bin/. `zappa` then fails to resolve. Prepending
+    Path(sys.executable).parent ensures the same interpreter's sibling scripts
+    (zappa) are found.
+    """
+    env = os.environ.copy()
+    if extra:
+        env.update(extra)
+    venv_bin = str(Path(sys.executable).parent)
+    env["PATH"] = f"{venv_bin}{os.pathsep}{env.get('PATH', '')}"
+    return env
 
 
 class DeploymentManager:
@@ -136,9 +155,6 @@ class DeploymentManager:
         # Get template directory from installed package
         template_dir = Path(__file__).parent / "templates"
 
-        # Get consuming project root from current working directory
-        consuming_project_root = Path.cwd()
-
         # Prepare replacements
         tags_dict = tags or {}
 
@@ -199,13 +215,14 @@ class DeploymentManager:
             ephemeral_storage=ephemeral_storage,
         )
 
-        # Copy pyproject.toml from consuming project
-        pyproject_src = consuming_project_root / "pyproject.toml"
-        if pyproject_src.exists():
-            shutil.copy2(pyproject_src, self.model_cache_dir / "pyproject.toml")
-            logger.info(f"Copied pyproject.toml from consuming project: {consuming_project_root}")
-        else:
-            logger.warning(f"pyproject.toml not found in consuming project: {consuming_project_root}")
+        # Generate a minimal pyproject.toml for the deployment image.
+        # Copying the consumer's pyproject.toml pulled in unrelated deps and failed
+        # when the consumer declared a readme/build backend the image didn't ship.
+        generate_from_template(
+            template_path=template_dir / "pyproject.toml.template",
+            output_path=self.model_cache_dir / "pyproject.toml",
+            replacements={"PROJECT_NAME": sanitize_for_cloudformation(self.project_name)},
+        )
 
         # Update configuration
         update_model_config(
@@ -679,9 +696,9 @@ class DeploymentManager:
         # Update zappa settings with authorizer ARN
         self._update_zappa_settings_with_authorizer(authorizer_arn)
 
-        # Set environment for deployment
-        env = os.environ.copy()
-        env["API_KEY"] = auth_token
+        # Set environment for deployment; ensure zappa (installed alongside merle)
+        # is resolvable even when merle was launched via its fully-qualified venv path.
+        env = _subprocess_env_with_venv_bin({"API_KEY": auth_token})
 
         # Run zappa deploy with retry logic
         cmd = ["zappa", "deploy", self.stage, "--docker-image-uri", image_uri]
@@ -791,13 +808,14 @@ class DeploymentManager:
 
         logger.info(f"Destroying deployment for model: {self.model_name}, stage: {self.stage}")
 
-        # Run zappa undeploy
+        # Run zappa undeploy (same PATH fix as deploy so zappa resolves from the venv)
         cmd = ["zappa", "undeploy", self.stage, "--yes"]
 
         logger.info(f"Running: {' '.join(cmd)}")
         result = subprocess.run(  # noqa: S603
             cmd,
             cwd=self.model_cache_dir,
+            env=_subprocess_env_with_venv_bin(),
             check=False,
             capture_output=False,
         )

--- a/merle/templates/Dockerfile.template
+++ b/merle/templates/Dockerfile.template
@@ -21,15 +21,16 @@ ENV UV_PROJECT_ENVIRONMENT=/var/lang/ \
 
 # AWS Lambda uses dnf/microdnf instead of apt-get
 # Install system dependencies (curl already installed, skip to avoid conflicts)
-RUN dnf install -y tar gzip ca-certificates procps git findutils || microdnf install -y tar gzip ca-certificates procps git findutils && \
+# zstd is required to extract the Ollama release tarball (tar.zst format since ~v0.20+)
+RUN dnf install -y tar gzip zstd ca-certificates procps git findutils || microdnf install -y tar gzip zstd ca-certificates procps git findutils && \
     dnf clean all || microdnf clean all
 
 # Download and install Ollama binary to /var/task/bin (required for Zappa ZIP deployment)
 # Zappa only packages files from /var/task/ when deploying as ZIP, so we must install here
-RUN curl -fsSL https://ollama.com/download/ollama-linux-amd64.tgz -o /tmp/ollama.tgz && \
+RUN curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst -o /tmp/ollama.tar.zst && \
     mkdir -p /var/task/bin && \
-    tar -xzf /tmp/ollama.tgz -C /var/task && \
-    rm /tmp/ollama.tgz && \
+    tar --zstd -xf /tmp/ollama.tar.zst -C /var/task && \
+    rm /tmp/ollama.tar.zst && \
     chmod +x /var/task/bin/ollama && \
     ls -la /var/task/bin/ollama && \
     /var/task/bin/ollama --version
@@ -45,8 +46,9 @@ WORKDIR ${FUNCTION_DIR}
 
 # Install Python dependencies using uv
 # Note: --frozen is not used because we don't copy uv.lock (architecture differences)
+# --no-install-project skips building the stub manifest; only its dependencies matter here
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-dev --inexact
+    uv sync --no-dev --inexact --no-install-project
 
 # Copy authorizer and Zappa settings JSON
 COPY authorizer.py ${FUNCTION_DIR}/

--- a/merle/templates/authorizer.py
+++ b/merle/templates/authorizer.py
@@ -27,13 +27,31 @@ def lambda_handler(event: dict[str, Any], _context: dict[str, Any]) -> dict[str,
 
     logger.info(f"Authorizer invoked for method: {method_arn}")
 
+    # API Gateway caches authorizer responses by token (result_ttl), not by method/path,
+    # so the policy must cover the whole API — otherwise the first request seeds the cache
+    # with a policy scoped to that single method and subsequent paths get 403.
+    api_resource = _api_wide_resource(method_arn)
+
     # Validate token
     if token == API_KEY:
         logger.info("Token validation successful")
-        return generate_policy("user", "Allow", method_arn)
+        return generate_policy("user", "Allow", api_resource)
 
     logger.warning("Token validation failed")
-    return generate_policy("user", "Deny", method_arn)
+    return generate_policy("user", "Deny", api_resource)
+
+
+def _api_wide_resource(method_arn: str) -> str:
+    """
+    Expand a method ARN to an API-wide wildcard ARN.
+
+    Input:  arn:aws:execute-api:region:account:api-id/stage/METHOD/path
+    Output: arn:aws:execute-api:region:account:api-id/*/*/*
+    """
+    if not method_arn or "/" not in method_arn:
+        return method_arn
+    api_arn = method_arn.split("/", 1)[0]
+    return f"{api_arn}/*/*/*"
 
 
 def generate_policy(principal_id: str, effect: str, resource: str) -> dict[str, Any]:

--- a/merle/templates/pyproject.toml.template
+++ b/merle/templates/pyproject.toml.template
@@ -1,0 +1,13 @@
+# Minimal pyproject.toml used only by the deployment Docker image build.
+# The consumer's own pyproject.toml is intentionally NOT copied into the image:
+# doing so pulled in the consumer's full dep tree (often GPU/ML stacks that the
+# Lambda never needs) and, if the consumer declared a readme/build backend,
+# crashed `uv sync` inside the container. This manifest only needs to install
+# merle itself and its transitive runtime deps (flask, zappa, httpx).
+[project]
+name = "{{PROJECT_NAME}}-runtime"
+version = "0.0.0"
+requires-python = ">=3.14,<3.15"
+dependencies = [
+    "merle @ git+https://github.com/zappa/zappa-merle.git",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "merle"
-version = "0.0.1"
+version = "0.0.3"
 description = "This project uses zappa/ollama to deploy ollama compatable models to AWS lambda"
 authors = [{ name = "monkut", email = "hakkoakkei@gmail.com" }]
 readme = "README.md"
@@ -21,7 +21,7 @@ license-files = ["LICENSE"]
 dependencies = [
     "flask>=3.1.0,<3.2.0",
     "httpx>=0.28.1",
-    "zappa==0.61.2",
+    "zappa>=0.61.2,<0.63",
 ]
 
 [project.urls]
@@ -35,20 +35,16 @@ dev = [
     "pyright>=1.1.396",
     "ruff>=0.9.10",
     "pytest>=8.3.5",
+    "pytest-cov>=6.0",
     "poethepoet>=0.34.0",
 ]
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.setuptools.packages.find]
-where = ["."]  # list of folders that contain the packages (["."] by default)
-include = ["merle", "merle.templates"]  # package names should match these glob patterns (["*"] by default)
-exclude = []  # exclude packages matching these glob patterns (empty by default)
-
-[tool.setuptools.package-data]
-merle = ["templates/*.template", "templates/*.py"]
+[tool.hatch.build.targets.wheel]
+packages = ["merle"]
 
 # Task runner
 [tool.poe.tasks]
@@ -62,7 +58,7 @@ put-project-data = "aws s3 cp ./data s3://zappa-merle/ --recursive"
 
 [tool.poe.tasks.test]
 # run the test command in a shell
-shell = "mkdir test-reports || true && uv run pytest -v tests/ --junitxml=test-reports/junit.xml"
+shell = "mkdir test-reports || true && uv run pytest -v tests/ --cov=merle --cov-report=term-missing --junitxml=test-reports/junit.xml"
 
 
 [tool.pyright]
@@ -81,7 +77,7 @@ markers = [
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version ='py313'
+target-version = 'py314'
 exclude = [".git", ".venv", "**/node_modules/", "**/.volta", "jupyter/*"]
 fix = true
 respect-gitignore = true
@@ -168,7 +164,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "**/cli.py" = ["T201", "TRY300", "TRY400", "TRY401", "PLC0415", "S603", "PLR0911", "PLR0915"]
 "**/chat.py" = ["T201", "TRY400", "TRY401"]
 "**/functions.py" = ["PLR2004", "TRY300", "TRY301", "TRY400", "TRY401", "B904"]
-"tests/**" = ["S105", "S106", "PLR2004", "FLY002", "ANN202", "ARG001", "F841", "TC003"]
+"tests/**" = ["S105", "S106", "PLR2004", "FLY002", "ANN001", "ANN202", "ARG001", "F841", "TC003"]
 
 [tool.ruff.lint.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds this value.

--- a/tests/test_authorizer.py
+++ b/tests/test_authorizer.py
@@ -1,0 +1,54 @@
+"""Tests for the generated API Gateway authorizer."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture
+def authorizer_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load merle/templates/authorizer.py as a module with a known API_KEY."""
+    monkeypatch.setenv("API_KEY", "secret-token")
+    path = Path(__file__).parent.parent / "merle" / "templates" / "authorizer.py"
+    spec = importlib.util.spec_from_file_location("merle_authorizer_under_test", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+METHOD_ARN = "arn:aws:execute-api:ap-northeast-1:123456789012:abcdef1234/dev/GET/"
+API_WIDE = "arn:aws:execute-api:ap-northeast-1:123456789012:abcdef1234/*/*/*"
+
+
+class TestApiWideResource:
+    """_api_wide_resource strips the stage/method/path suffix and adds the wildcard."""
+
+    def test_rewrites_single_method_arn_to_api_wildcard(self, authorizer_module):
+        assert authorizer_module._api_wide_resource(METHOD_ARN) == API_WIDE
+
+    def test_rewrites_post_arn_to_same_wildcard(self, authorizer_module):
+        post_arn = "arn:aws:execute-api:ap-northeast-1:123456789012:abcdef1234/dev/POST/api/generate"
+        assert authorizer_module._api_wide_resource(post_arn) == API_WIDE
+
+    def test_empty_input_passes_through(self, authorizer_module):
+        assert authorizer_module._api_wide_resource("") == ""
+
+
+class TestLambdaHandler:
+    """Cached authorizer responses must permit the whole API for the token, not one method."""
+
+    def test_allow_policy_uses_wildcard_resource(self, authorizer_module):
+        response = authorizer_module.lambda_handler({"authorizationToken": "secret-token", "methodArn": METHOD_ARN}, {})
+        statement = response["policyDocument"]["Statement"][0]
+        assert statement["Effect"] == "Allow"
+        assert statement["Resource"] == API_WIDE
+
+    def test_deny_policy_uses_wildcard_resource(self, authorizer_module):
+        response = authorizer_module.lambda_handler({"authorizationToken": "wrong-token", "methodArn": METHOD_ARN}, {})
+        statement = response["policyDocument"]["Statement"][0]
+        assert statement["Effect"] == "Deny"
+        assert statement["Resource"] == API_WIDE

--- a/tests/test_deployment_completeness.py
+++ b/tests/test_deployment_completeness.py
@@ -7,9 +7,18 @@ from unittest.mock import MagicMock, patch
 from merle.cli import handle_prepare_dockerfile
 
 
+def _fake_copy_model_to_output(_model_name: str, output_dir: Path) -> None:
+    """Mock for copy_model_to_output that creates an empty models/ dir in output."""
+    (output_dir / "models").mkdir(parents=True, exist_ok=True)
+
+
 class TestDeploymentCompleteness:
     """Test that verifies what's missing for successful deployment."""
 
+    @patch("merle.model_split.copy_model_to_output", side_effect=_fake_copy_model_to_output)
+    @patch("merle.model_split.needs_splitting", return_value=False)
+    @patch("merle.model_split.calculate_model_size", return_value=(1024, {"total_size_gb": 0.001}))
+    @patch("merle.model_split.download_model_locally")
     @patch("merle.model_split.get_ollama_models_dir")
     @patch("merle.functions.validate_ollama_model")
     @patch("merle.cli.get_default_project_name")
@@ -18,6 +27,10 @@ class TestDeploymentCompleteness:
         mock_get_default_project: MagicMock,
         mock_validate: MagicMock,
         mock_models_dir_fn: MagicMock,
+        mock_download: MagicMock,
+        mock_calc_size: MagicMock,
+        mock_needs_split: MagicMock,
+        mock_copy_model: MagicMock,
         temp_cache_dir: Path,
         mock_models_dir: Path,
     ) -> None:
@@ -60,6 +73,10 @@ class TestDeploymentCompleteness:
         config_path = temp_cache_dir / "testproject" / "config.json"
         assert config_path.exists(), "config.json should be created"
 
+    @patch("merle.model_split.copy_model_to_output", side_effect=_fake_copy_model_to_output)
+    @patch("merle.model_split.needs_splitting", return_value=False)
+    @patch("merle.model_split.calculate_model_size", return_value=(1024, {"total_size_gb": 0.001}))
+    @patch("merle.model_split.download_model_locally")
     @patch("merle.model_split.get_ollama_models_dir")
     @patch("merle.functions.validate_ollama_model")
     @patch("merle.cli.get_default_project_name")
@@ -68,6 +85,10 @@ class TestDeploymentCompleteness:
         mock_get_default_project: MagicMock,
         mock_validate: MagicMock,
         mock_models_dir_fn: MagicMock,
+        mock_download: MagicMock,
+        mock_calc_size: MagicMock,
+        mock_needs_split: MagicMock,
+        mock_copy_model: MagicMock,
         temp_cache_dir: Path,
         mock_models_dir: Path,
     ) -> None:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -438,6 +438,7 @@ class TestPrepareDeploymentFiles:
             auth_token="test-token",
             aws_region="us-east-1",
             s3_bucket="test-bucket",
+            skip_model_download=True,
         )
 
         # Verify model cache directory was created
@@ -476,6 +477,7 @@ class TestPrepareDeploymentFiles:
             auth_token="test-token",
             tags=sample_tags,
             s3_bucket="test-bucket-tags",
+            skip_model_download=True,
         )
 
         # Verify zappa_settings.json contains tags
@@ -505,6 +507,7 @@ class TestPrepareDeploymentFiles:
             project_name="testproject",
             auth_token="test-token-no-tags",
             s3_bucket="test-bucket-no-tags",
+            skip_model_download=True,
         )
 
         # Verify zappa_settings.json has empty tags

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -310,6 +310,31 @@ class TestGenerateFromTemplate:
         assert output_path.read_text() == "Content: test"
 
 
+class TestDockerfileTemplate:
+    """Regression tests for the Dockerfile template (Issue #2)."""
+
+    @pytest.fixture
+    def dockerfile_template(self) -> str:
+        template_path = Path(__file__).parent.parent / "merle" / "templates" / "Dockerfile.template"
+        return template_path.read_text()
+
+    def test_downloads_zstd_tarball(self, dockerfile_template: str):
+        """Ollama switched Linux release from .tgz (404) to .tar.zst."""
+        assert "ollama-linux-amd64.tar.zst" in dockerfile_template
+        assert "ollama-linux-amd64.tgz" not in dockerfile_template
+
+    def test_extracts_with_zstd(self, dockerfile_template: str):
+        assert "tar --zstd" in dockerfile_template
+
+    def test_installs_zstd_package(self, dockerfile_template: str):
+        """Tar --zstd requires zstd to be installed in the Lambda base image."""
+        assert "zstd" in dockerfile_template
+
+    def test_uv_sync_does_not_install_stub_project(self, dockerfile_template: str):
+        """The generated pyproject is a stub; don't try to build it (Issue #3)."""
+        assert "--no-install-project" in dockerfile_template
+
+
 class TestGenerateZappaSettings:
     """Tests for _generate_zappa_settings function."""
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -313,7 +313,7 @@ class TestGenerateFromTemplate:
 class TestDockerfileTemplate:
     """Regression tests for the Dockerfile template (Issue #2)."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def dockerfile_template(self) -> str:
         template_path = Path(__file__).parent.parent / "merle" / "templates" / "Dockerfile.template"
         return template_path.read_text()

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,0 +1,411 @@
+"""Tests for merle.managers module."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from merle.managers import DeploymentManager, _subprocess_env_with_venv_bin
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> DeploymentManager:
+    """Create a DeploymentManager instance for testing."""
+    return DeploymentManager(
+        model_name="llama2",
+        cache_dir=tmp_path / "cache",
+        project_name="test-project",
+        stage="dev",
+        region="us-east-1",
+    )
+
+
+@pytest.fixture
+def prepared_manager(manager: DeploymentManager) -> DeploymentManager:
+    """Create a DeploymentManager with prepared deployment files."""
+    manager.model_cache_dir.mkdir(parents=True, exist_ok=True)
+    settings = {
+        "dev": {
+            "app_function": "merle.app.app",
+            "project_name": "test-project",
+            "s3_bucket": "test-bucket",
+            "aws_region": "us-east-1",
+            "memory_size": 8192,
+            "timeout_seconds": 900,
+            "docker_image_uri": "123456789.dkr.ecr.us-east-1.amazonaws.com/merle-llama2:latest",
+        }
+    }
+    manager.zappa_settings_path.write_text(json.dumps(settings))
+    return manager
+
+
+class TestDeploymentManagerProperties:
+    """Tests for DeploymentManager property methods."""
+
+    def test_model_cache_dir(self, manager):
+        cache_dir = manager.model_cache_dir
+        assert isinstance(cache_dir, Path)
+        assert "llama2" in str(cache_dir)
+
+    def test_zappa_settings_path(self, manager):
+        path = manager.zappa_settings_path
+        assert path.name == "zappa_settings.json"
+
+    def test_is_prepared_false(self, manager):
+        assert manager.is_prepared is False
+
+    def test_is_prepared_true(self, prepared_manager):
+        assert prepared_manager.is_prepared is True
+
+    def test_normalized_model_name(self, manager):
+        assert manager.normalized_model_name == "llama2"
+
+    def test_normalized_model_name_with_slashes(self, tmp_path):
+        mgr = DeploymentManager(
+            model_name="user/model:tag",
+            cache_dir=tmp_path,
+            project_name="proj",
+        )
+        assert "/" not in mgr.normalized_model_name
+        assert ":" not in mgr.normalized_model_name
+
+    def test_ecr_repo_name(self, manager):
+        assert manager.ecr_repo_name == "merle-llama2"
+
+    def test_region_defaults_to_settings(self, tmp_path):
+        with patch("merle.managers.REGION", "ap-northeast-1"):
+            mgr = DeploymentManager(
+                model_name="llama2",
+                cache_dir=tmp_path,
+                project_name="proj",
+            )
+            assert mgr.region == "ap-northeast-1"
+
+    def test_region_override(self, manager):
+        assert manager.region == "us-east-1"
+
+
+class TestCalculateEphemeralStorage:
+    """Tests for _calculate_ephemeral_storage."""
+
+    def test_small_model_gets_minimum(self, manager):
+        result = manager._calculate_ephemeral_storage(0.0)
+        assert result == 512
+
+    def test_large_model_gets_clamped(self, manager):
+        result = manager._calculate_ephemeral_storage(20.0)
+        assert result == 10240
+
+    def test_medium_model_rounds_up(self, manager):
+        result = manager._calculate_ephemeral_storage(3.0)
+        assert result % 512 == 0
+        assert result >= 3 * 1024  # at least the model size in MB
+
+
+class TestGetAuthorizerLambdaName:
+    """Tests for _get_authorizer_lambda_name."""
+
+    def test_name_format(self, manager):
+        name = manager._get_authorizer_lambda_name()
+        assert name.endswith("-dev-authorizer")
+        assert "test" in name.lower()
+
+    def test_name_with_different_stage(self, tmp_path):
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="myproj",
+            stage="prod",
+        )
+        name = mgr._get_authorizer_lambda_name()
+        assert name.endswith("-prod-authorizer")
+
+
+class TestGenerateZappaSettings:
+    """Tests for _generate_zappa_settings."""
+
+    @patch("merle.managers.ZappaCLI")
+    def test_generates_settings_file(self, mock_zappa_cli_cls, manager):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        manager.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        manager._generate_zappa_settings(
+            auth_token="test-token",
+            s3_bucket="my-bucket",
+            tags={"Env": "dev"},
+            memory_size=8192,
+        )
+
+        assert manager.zappa_settings_path.exists()
+        settings = json.loads(manager.zappa_settings_path.read_text())
+        assert "dev" in settings
+        assert settings["dev"]["app_function"] == "merle.app.app"
+        assert settings["dev"]["s3_bucket"] == "my-bucket"
+        assert settings["dev"]["memory_size"] == 8192
+
+    @patch("merle.managers.ZappaCLI")
+    def test_split_mode_adds_s3_permissions(self, mock_zappa_cli_cls, manager):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        manager.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        manager._generate_zappa_settings(
+            auth_token="test-token",
+            s3_bucket="my-bucket",
+            tags={},
+            use_split=True,
+        )
+
+        settings = json.loads(manager.zappa_settings_path.read_text())
+        assert "extra_permissions" in settings["dev"]
+        assert settings["dev"]["environment_variables"]["MERLE_SPLIT_MODEL"] == "true"
+
+    @patch("merle.managers.ZappaCLI")
+    def test_context_window_env_var(self, mock_zappa_cli_cls, manager):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        manager.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        manager._generate_zappa_settings(
+            auth_token="tok",
+            s3_bucket="bkt",
+            tags={},
+            context_window_size=4096,
+        )
+
+        settings = json.loads(manager.zappa_settings_path.read_text())
+        assert settings["dev"]["environment_variables"]["OLLAMA_MODEL_CONTEXT_WINDOW_SIZE"] == "4096"
+
+    @patch("merle.managers.ZappaCLI")
+    def test_authorizer_arn_used_when_provided(self, mock_zappa_cli_cls, manager):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        manager.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        manager._generate_zappa_settings(
+            auth_token="tok",
+            s3_bucket="bkt",
+            tags={},
+            authorizer_arn="arn:aws:lambda:us-east-1:123:function:auth",
+        )
+
+        settings = json.loads(manager.zappa_settings_path.read_text())
+        assert settings["dev"]["authorizer"]["arn"] == "arn:aws:lambda:us-east-1:123:function:auth"
+
+
+class TestUpdateZappaSettingsWithImageUri:
+    """Tests for _update_zappa_settings_with_image_uri."""
+
+    def test_adds_docker_image_uri(self, prepared_manager):
+        new_uri = "999.dkr.ecr.us-east-1.amazonaws.com/merle-llama2:v2"
+        prepared_manager._update_zappa_settings_with_image_uri(new_uri)
+
+        settings = json.loads(prepared_manager.zappa_settings_path.read_text())
+        assert settings["dev"]["docker_image_uri"] == new_uri
+
+
+class TestUpdateZappaSettingsWithAuthorizer:
+    """Tests for _update_zappa_settings_with_authorizer."""
+
+    def test_updates_authorizer_config(self, prepared_manager):
+        arn = "arn:aws:lambda:us-east-1:123:function:my-auth"
+        prepared_manager._update_zappa_settings_with_authorizer(arn)
+
+        settings = json.loads(prepared_manager.zappa_settings_path.read_text())
+        assert settings["dev"]["authorizer"]["arn"] == arn
+        assert settings["dev"]["authorizer"]["token_header"] == "X-API-Key"
+        assert settings["dev"]["authorizer"]["result_ttl"] == 300
+
+
+class TestBuildAndPushDockerImage:
+    """Tests for build_and_push_docker_image."""
+
+    def test_raises_if_not_prepared(self, manager):
+        with pytest.raises(RuntimeError, match="not prepared"):
+            manager.build_and_push_docker_image()
+
+    @patch("merle.managers.subprocess.run")
+    @patch("merle.managers.boto3.client")
+    def test_creates_ecr_repo_and_pushes(self, mock_boto_client, mock_run, prepared_manager):
+        mock_ecr = MagicMock()
+        mock_ecr.describe_repositories.return_value = {
+            "repositories": [{"repositoryUri": "123.dkr.ecr.us-east-1.amazonaws.com/merle-llama2"}]
+        }
+        mock_ecr.get_authorization_token.return_value = {
+            "authorizationData": [
+                {
+                    "authorizationToken": "dXNlcjpwYXNz",  # base64("user:pass")
+                    "proxyEndpoint": "https://123.dkr.ecr.us-east-1.amazonaws.com",
+                }
+            ]
+        }
+        mock_ecr.exceptions = MagicMock()
+        mock_ecr.exceptions.RepositoryAlreadyExistsException = type("RepoExists", (Exception,), {})
+        mock_boto_client.return_value = mock_ecr
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        image_uri = prepared_manager.build_and_push_docker_image()
+        assert "merle-llama2:latest" in image_uri
+        assert mock_run.call_count == 3  # login, build, push
+
+
+class TestDeploy:
+    """Tests for deploy."""
+
+    def test_raises_if_not_prepared(self, manager):
+        with pytest.raises(RuntimeError, match="not prepared"):
+            manager.deploy(auth_token="test")
+
+    @patch("merle.managers.subprocess.run")
+    @patch("merle.managers.boto3.client")
+    @patch.object(DeploymentManager, "_get_or_create_authorizer_role", return_value="arn:aws:iam::123:role/auth-role")
+    @patch.object(
+        DeploymentManager,
+        "_deploy_authorizer_lambda",
+        return_value="arn:aws:lambda:us-east-1:123:function:auth",
+    )
+    @patch.object(
+        DeploymentManager, "get_deployment_url", return_value="https://example.execute-api.us-east-1.amazonaws.com/dev"
+    )
+    @patch("merle.managers.update_model_config")
+    def test_deploys_with_zappa(
+        self,
+        mock_update_config,
+        mock_get_url,
+        mock_deploy_auth,
+        mock_create_role,
+        mock_boto_client,
+        mock_run,
+        prepared_manager,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="Deployed!", stderr="")
+
+        url = prepared_manager.deploy(auth_token="test-token")
+        assert url is not None
+        mock_run.assert_called_once()
+        mock_deploy_auth.assert_called_once()
+
+
+class TestDestroy:
+    """Tests for destroy."""
+
+    def test_returns_false_if_not_prepared(self, manager):
+        assert manager.destroy() is False
+
+    @patch("merle.managers.subprocess.run")
+    @patch.object(DeploymentManager, "_delete_authorizer_lambda")
+    @patch.object(DeploymentManager, "_delete_authorizer_role")
+    @patch.object(DeploymentManager, "_cleanup_local_files")
+    def test_calls_zappa_undeploy(self, mock_cleanup, mock_del_role, mock_del_lambda, mock_run, prepared_manager):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = prepared_manager.destroy()
+        assert result is True
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "undeploy" in cmd
+        assert "--yes" in cmd
+        mock_del_lambda.assert_called_once()
+        mock_del_role.assert_called_once()
+        mock_cleanup.assert_called_once()
+
+    @patch("merle.managers.subprocess.run")
+    @patch.object(DeploymentManager, "_delete_authorizer_lambda")
+    @patch.object(DeploymentManager, "_delete_authorizer_role")
+    @patch.object(DeploymentManager, "_cleanup_local_files")
+    def test_returns_false_on_zappa_failure(
+        self, mock_cleanup, mock_del_role, mock_del_lambda, mock_run, prepared_manager
+    ):
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result = prepared_manager.destroy()
+        assert result is False
+        # Cleanup should still happen
+        mock_del_lambda.assert_called_once()
+        mock_del_role.assert_called_once()
+        mock_cleanup.assert_called_once()
+
+
+class TestSubprocessEnvWithVenvBin:
+    """Tests for _subprocess_env_with_venv_bin (zappa PATH fix for Issue #4)."""
+
+    def test_prepends_sys_executable_bin_to_path(self):
+        env = _subprocess_env_with_venv_bin()
+        expected_bin = str(Path(sys.executable).parent)
+        assert env["PATH"].startswith(f"{expected_bin}{os.pathsep}")
+
+    def test_merges_extra_env_variables(self):
+        env = _subprocess_env_with_venv_bin({"API_KEY": "tok", "FOO": "bar"})
+        assert env["API_KEY"] == "tok"
+        assert env["FOO"] == "bar"
+
+    def test_preserves_existing_path_entries(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/existing/bin")
+        env = _subprocess_env_with_venv_bin()
+        assert "/existing/bin" in env["PATH"]
+
+
+class TestPrepareGeneratesMinimalPyproject:
+    """Preparation should emit a minimal pyproject, not copy the consumer's (Issue #3)."""
+
+    @patch("merle.managers.ZappaCLI")
+    @patch("merle.managers.update_model_config")
+    @patch("merle.managers.validate_ollama_model", return_value=True)
+    def test_generates_template_pyproject_with_merle_dependency(
+        self,
+        mock_validate,
+        mock_update,
+        mock_zappa_cli_cls,
+        manager,
+    ):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        manager.prepare(auth_token="tok", s3_bucket="bkt", skip_model_download=True)
+
+        pyproject = (manager.model_cache_dir / "pyproject.toml").read_text()
+        assert "merle @ git+https://github.com/zappa/zappa-merle.git" in pyproject
+        assert "-runtime" in pyproject
+        mock_validate.assert_called_once()
+        mock_update.assert_called_once()
+
+
+class TestCleanupLocalFiles:
+    """Tests for _cleanup_local_files."""
+
+    @patch("merle.functions.save_config")
+    @patch("merle.functions.load_config")
+    def test_removes_model_from_config(self, mock_load, mock_save, prepared_manager):
+        mock_load.return_value = {
+            "models": {
+                "llama2": {
+                    "dev": {"auth_token": "tok"},
+                }
+            }
+        }
+
+        prepared_manager._cleanup_local_files()
+
+        saved_config = mock_save.call_args[0][1]
+        assert "llama2" not in saved_config.get("models", {})
+
+    @patch("merle.functions.save_config")
+    @patch("merle.functions.load_config")
+    def test_deletes_cache_directory(self, mock_load, mock_save, prepared_manager):
+        mock_load.return_value = {"models": {}}
+        cache_dir = prepared_manager.model_cache_dir
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "somefile.txt").write_text("test")
+
+        prepared_manager._cleanup_local_files()
+        assert not cache_dir.exists()

--- a/tests/test_model_split.py
+++ b/tests/test_model_split.py
@@ -1,0 +1,386 @@
+"""Tests for merle.model_split module."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from merle.model_split import (
+    MAX_MODEL_SIZE_IN_IMAGE,
+    _get_model_blob_digests,
+    _get_model_manifest_path,
+    _get_platform_models_dirs,
+    calculate_directory_size,
+    calculate_model_size,
+    calculate_split_sizes,
+    find_largest_blob,
+    get_ollama_models_dir,
+    needs_splitting,
+    reassemble_blob,
+    split_blob_file,
+)
+
+
+class TestGetPlatformModelsDirs:
+    """Tests for _get_platform_models_dirs."""
+
+    @patch("merle.model_split.sys")
+    def test_macos_returns_home_dir(self, mock_sys):
+        mock_sys.platform = "darwin"
+        dirs = _get_platform_models_dirs()
+        assert len(dirs) == 1
+        assert dirs[0] == Path.home() / ".ollama" / "models"
+
+    @patch("merle.model_split.sys")
+    def test_windows_returns_home_dir(self, mock_sys):
+        mock_sys.platform = "win32"
+        dirs = _get_platform_models_dirs()
+        assert len(dirs) == 1
+        assert dirs[0] == Path.home() / ".ollama" / "models"
+
+    @patch("merle.model_split.sys")
+    def test_linux_returns_systemd_and_user_dirs(self, mock_sys):
+        mock_sys.platform = "linux"
+        dirs = _get_platform_models_dirs()
+        assert len(dirs) == 2
+        assert dirs[0] == Path("/usr/share/ollama/.ollama/models")
+        assert dirs[1] == Path.home() / ".ollama" / "models"
+
+
+class TestGetOllamaModelsDir:
+    """Tests for get_ollama_models_dir."""
+
+    def test_env_variable_takes_precedence(self, tmp_path):
+        env_dir = str(tmp_path / "custom_models")
+        with patch.dict("os.environ", {"OLLAMA_MODELS": env_dir}):
+            result = get_ollama_models_dir()
+            assert result == Path(env_dir)
+
+    def test_returns_existing_platform_dir(self, tmp_path):
+        env = {k: v for k, v in os.environ.items() if k != "OLLAMA_MODELS"}
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("merle.model_split._get_platform_models_dirs", return_value=[tmp_path]),
+        ):
+            result = get_ollama_models_dir()
+            assert result == tmp_path
+
+    def test_falls_back_to_first_default(self):
+        non_existent = Path("/nonexistent/path/models")
+        env = {k: v for k, v in os.environ.items() if k != "OLLAMA_MODELS"}
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("merle.model_split._get_platform_models_dirs", return_value=[non_existent]),
+        ):
+            result = get_ollama_models_dir()
+            assert result == non_existent
+
+
+class TestCalculateDirectorySize:
+    """Tests for calculate_directory_size."""
+
+    def test_empty_directory(self, tmp_path):
+        assert calculate_directory_size(tmp_path) == 0
+
+    def test_single_file(self, tmp_path):
+        f = tmp_path / "file.bin"
+        f.write_bytes(b"x" * 1024)
+        assert calculate_directory_size(tmp_path) == 1024
+
+    def test_nested_files(self, tmp_path):
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (tmp_path / "a.bin").write_bytes(b"x" * 100)
+        (sub / "b.bin").write_bytes(b"y" * 200)
+        assert calculate_directory_size(tmp_path) == 300
+
+
+class TestGetModelManifestPath:
+    """Tests for _get_model_manifest_path."""
+
+    def test_simple_model_name(self, tmp_path):
+        manifest = tmp_path / "manifests" / "registry.ollama.ai" / "library" / "llama2" / "latest"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("{}")
+        result = _get_model_manifest_path("llama2", tmp_path)
+        assert result == manifest
+
+    def test_model_with_tag(self, tmp_path):
+        manifest = tmp_path / "manifests" / "registry.ollama.ai" / "library" / "llama2" / "7b"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("{}")
+        result = _get_model_manifest_path("llama2:7b", tmp_path)
+        assert result == manifest
+
+    def test_user_model(self, tmp_path):
+        manifest = tmp_path / "manifests" / "registry.ollama.ai" / "myuser" / "mymodel" / "latest"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("{}")
+        result = _get_model_manifest_path("myuser/mymodel", tmp_path)
+        assert result == manifest
+
+    def test_huggingface_model(self, tmp_path):
+        manifest = tmp_path / "manifests" / "hf.co" / "org" / "model" / "latest"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("{}")
+        result = _get_model_manifest_path("hf.co/org/model", tmp_path)
+        assert result == manifest
+
+    def test_huggingface_model_with_tag(self, tmp_path):
+        manifest = tmp_path / "manifests" / "hf.co" / "org" / "model" / "Q4_K_M"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("{}")
+        result = _get_model_manifest_path("hf.co/org/model:Q4_K_M", tmp_path)
+        assert result == manifest
+
+    def test_nonexistent_model_returns_none(self, tmp_path):
+        result = _get_model_manifest_path("nonexistent", tmp_path)
+        assert result is None
+
+
+class TestGetModelBlobDigests:
+    """Tests for _get_model_blob_digests."""
+
+    def test_extracts_config_and_layer_digests(self, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "config": {"digest": "sha256:config123"},
+                    "layers": [
+                        {"digest": "sha256:layer1abc"},
+                        {"digest": "sha256:layer2def"},
+                    ],
+                }
+            )
+        )
+        result = _get_model_blob_digests(manifest)
+        assert result == ["sha256-config123", "sha256-layer1abc", "sha256-layer2def"]
+
+    def test_handles_missing_config(self, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"layers": [{"digest": "sha256:abc"}]}))
+        result = _get_model_blob_digests(manifest)
+        assert result == ["sha256-abc"]
+
+    def test_handles_empty_layers(self, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"config": {"digest": "sha256:cfg"}, "layers": []}))
+        result = _get_model_blob_digests(manifest)
+        assert result == ["sha256-cfg"]
+
+
+class TestFindLargestBlob:
+    """Tests for find_largest_blob."""
+
+    def test_no_blobs_dir(self, tmp_path):
+        assert find_largest_blob(tmp_path) is None
+
+    def test_empty_blobs_dir(self, tmp_path):
+        (tmp_path / "blobs").mkdir()
+        assert find_largest_blob(tmp_path) is None
+
+    def test_finds_largest(self, tmp_path):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / "small").write_bytes(b"x" * 100)
+        (blobs / "large").write_bytes(b"x" * 1000)
+        (blobs / "medium").write_bytes(b"x" * 500)
+        result = find_largest_blob(tmp_path)
+        assert result is not None
+        assert result[0].name == "large"
+        assert result[1] == 1000
+
+    def test_filter_by_model_name(self, tmp_path):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / "sha256-abc").write_bytes(b"x" * 500)
+        (blobs / "sha256-def").write_bytes(b"x" * 1000)
+
+        # Create manifest referencing only sha256-abc
+        manifest = tmp_path / "manifests" / "registry.ollama.ai" / "library" / "test" / "latest"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(json.dumps({"layers": [{"digest": "sha256:abc"}]}))
+
+        result = find_largest_blob(tmp_path, model_name="test")
+        assert result is not None
+        assert result[0].name == "sha256-abc"
+        assert result[1] == 500
+
+
+class TestCalculateModelSize:
+    """Tests for calculate_model_size."""
+
+    def test_with_manifest(self, tmp_path):
+        # Set up blobs
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / "sha256-cfg").write_bytes(b"c" * 100)
+        (blobs / "sha256-layer1").write_bytes(b"a" * 500)
+
+        # Set up manifest
+        manifest = tmp_path / "manifests" / "registry.ollama.ai" / "library" / "mymodel" / "latest"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "config": {"digest": "sha256:cfg"},
+                    "layers": [{"digest": "sha256:layer1"}],
+                }
+            )
+        )
+
+        with patch("merle.model_split.get_ollama_models_dir", return_value=tmp_path):
+            total_size, details = calculate_model_size("mymodel")
+
+        assert total_size == 600
+        assert details["blob_count"] == 2
+        assert details["largest_blob"]["name"] == "sha256-layer1"
+
+    def test_fallback_without_manifest(self, tmp_path):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / "sha256-abc").write_bytes(b"x" * 1024)
+
+        with patch("merle.model_split.get_ollama_models_dir", return_value=tmp_path):
+            total_size, details = calculate_model_size("nonexistent")
+
+        assert total_size == 1024
+        assert "manifest_path" not in details
+
+
+class TestNeedsSplitting:
+    """Tests for needs_splitting."""
+
+    def test_small_model_no_split(self):
+        assert needs_splitting(1024) is False
+
+    def test_exact_limit_no_split(self):
+        assert needs_splitting(MAX_MODEL_SIZE_IN_IMAGE) is False
+
+    def test_over_limit_needs_split(self):
+        assert needs_splitting(MAX_MODEL_SIZE_IN_IMAGE + 1) is True
+
+
+class TestCalculateSplitSizes:
+    """Tests for calculate_split_sizes."""
+
+    def test_small_model_no_s3(self):
+        image, s3 = calculate_split_sizes(1024)
+        assert image == 1024
+        assert s3 == 0
+
+    def test_large_model_splits(self):
+        total = MAX_MODEL_SIZE_IN_IMAGE + 2 * 1024 * 1024 * 1024  # 5GB + 2GB
+        image, s3 = calculate_split_sizes(total)
+        assert image == MAX_MODEL_SIZE_IN_IMAGE
+        assert s3 == total - MAX_MODEL_SIZE_IN_IMAGE
+        assert image + s3 == total
+
+
+class TestSplitBlobFile:
+    """Tests for split_blob_file."""
+
+    def test_split_produces_two_parts(self, tmp_path):
+        blob = tmp_path / "source" / "sha256-testblob"
+        blob.parent.mkdir(parents=True)
+        data = b"A" * 1000 + b"B" * 500
+        blob.write_bytes(data)
+
+        output_dir = tmp_path / "output"
+        metadata = split_blob_file(blob, 1000, output_dir)
+
+        assert metadata["original_blob_size"] == 1500
+        assert metadata["part1"]["size"] == 1000
+        assert metadata["part2"]["size"] == 500
+
+        # Verify files exist
+        part1 = output_dir / "blobs" / "sha256-testblob.part1"
+        part2 = output_dir / "s3_overflow" / "sha256-testblob.part2"
+        assert part1.exists()
+        assert part2.exists()
+        assert part1.read_bytes() == b"A" * 1000
+        assert part2.read_bytes() == b"B" * 500
+
+    def test_split_sha256_integrity(self, tmp_path):
+        blob = tmp_path / "source" / "sha256-intblob"
+        blob.parent.mkdir(parents=True)
+        data = b"X" * 2048
+        blob.write_bytes(data)
+
+        expected_hash = hashlib.sha256(data).hexdigest()
+        output_dir = tmp_path / "output"
+        metadata = split_blob_file(blob, 1024, output_dir)
+
+        assert metadata["original_blob_sha256"] == expected_hash
+
+        # Verify part hashes
+        part1_path = output_dir / "blobs" / "sha256-intblob.part1"
+        part2_path = output_dir / "s3_overflow" / "sha256-intblob.part2"
+        assert hashlib.sha256(part1_path.read_bytes()).hexdigest() == metadata["part1"]["sha256"]
+        assert hashlib.sha256(part2_path.read_bytes()).hexdigest() == metadata["part2"]["sha256"]
+
+
+class TestReassembleBlob:
+    """Tests for reassemble_blob."""
+
+    def test_reassemble_matches_original(self, tmp_path):
+        original_data = b"Hello" * 200
+        part1 = tmp_path / "part1"
+        part2 = tmp_path / "part2"
+        part1.write_bytes(original_data[:500])
+        part2.write_bytes(original_data[500:])
+
+        output = tmp_path / "reassembled"
+        expected_sha = hashlib.sha256(original_data).hexdigest()
+
+        result = reassemble_blob(part1, part2, output, expected_sha256=expected_sha)
+        assert result is True
+        assert output.read_bytes() == original_data
+
+    def test_reassemble_sha256_mismatch(self, tmp_path):
+        part1 = tmp_path / "part1"
+        part2 = tmp_path / "part2"
+        part1.write_bytes(b"aaa")
+        part2.write_bytes(b"bbb")
+
+        output = tmp_path / "reassembled"
+        result = reassemble_blob(part1, part2, output, expected_sha256="wrong_hash")
+        assert result is False
+        assert not output.exists()
+
+    def test_reassemble_without_sha_verification(self, tmp_path):
+        part1 = tmp_path / "part1"
+        part2 = tmp_path / "part2"
+        part1.write_bytes(b"abc")
+        part2.write_bytes(b"def")
+
+        output = tmp_path / "reassembled"
+        result = reassemble_blob(part1, part2, output)
+        assert result is True
+        assert output.read_bytes() == b"abcdef"
+
+
+class TestSplitAndReassembleRoundTrip:
+    """Integration test: split a blob and reassemble it."""
+
+    def test_roundtrip_integrity(self, tmp_path):
+        # Create original blob
+        blob = tmp_path / "source" / "sha256-roundtrip"
+        blob.parent.mkdir(parents=True)
+        original_data = bytes(range(256)) * 100  # 25.6KB of varied data
+        blob.write_bytes(original_data)
+
+        # Split
+        output_dir = tmp_path / "split_output"
+        metadata = split_blob_file(blob, len(original_data) // 3, output_dir)
+
+        # Reassemble
+        part1 = output_dir / "blobs" / metadata["part1"]["filename"]
+        part2 = output_dir / "s3_overflow" / metadata["part2"]["filename"]
+        reassembled = tmp_path / "reassembled"
+
+        result = reassemble_blob(part1, part2, reassembled, expected_sha256=metadata["original_blob_sha256"])
+        assert result is True
+        assert reassembled.read_bytes() == original_data

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,41 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/43/3e4ac666cc35f231fa70c94e9f38459299de1a152813f9d2f60fc5f3ecaf/coverage-7.13.3.tar.gz", hash = "sha256:f7f6182d3dfb8802c1747eacbfe611b669455b69b7c037484bb1efbbb56711ac", size = 826832, upload-time = "2026-02-03T14:02:30.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/b3/677bb43427fed9298905106f39c6520ac75f746f81b8f01104526a8026e4/coverage-7.13.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c6f6169bbdbdb85aab8ac0392d776948907267fcc91deeacf6f9d55f7a83ae3b", size = 219513, upload-time = "2026-02-03T14:01:34.29Z" },
+    { url = "https://files.pythonhosted.org/packages/42/53/290046e3bbf8986cdb7366a42dab3440b9983711eaff044a51b11006c67b/coverage-7.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2f5e731627a3d5ef11a2a35aa0c6f7c435867c7ccbc391268eb4f2ca5dbdcc10", size = 219850, upload-time = "2026-02-03T14:01:35.984Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/ab41f10345ba2e49d5e299be8663be2b7db33e77ac1b85cd0af985ea6406/coverage-7.13.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9db3a3285d91c0b70fab9f39f0a4aa37d375873677efe4e71e58d8321e8c5d39", size = 250886, upload-time = "2026-02-03T14:01:38.287Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2d/b3f6913ee5a1d5cdd04106f257e5fac5d048992ffc2d9995d07b0f17739f/coverage-7.13.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06e49c5897cb12e3f7ecdc111d44e97c4f6d0557b81a7a0204ed70a8b038f86f", size = 253393, upload-time = "2026-02-03T14:01:40.118Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f6/b1f48810ffc6accf49a35b9943636560768f0812330f7456aa87dc39aff5/coverage-7.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb25061a66802df9fc13a9ba1967d25faa4dae0418db469264fd9860a921dde4", size = 254740, upload-time = "2026-02-03T14:01:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d0/e59c54f9be0b61808f6bc4c8c4346bd79f02dd6bbc3f476ef26124661f20/coverage-7.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:99fee45adbb1caeb914da16f70e557fb7ff6ddc9e4b14de665bd41af631367ef", size = 250905, upload-time = "2026-02-03T14:01:44.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f7/5291bcdf498bafbee3796bb32ef6966e9915aebd4d0954123c8eae921c32/coverage-7.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:318002f1fd819bdc1651c619268aa5bc853c35fa5cc6d1e8c96bd9cd6c828b75", size = 252753, upload-time = "2026-02-03T14:01:45.974Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a9/1dcafa918c281554dae6e10ece88c1add82db685be123e1b05c2056ff3fb/coverage-7.13.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:71295f2d1d170b9977dc386d46a7a1b7cbb30e5405492529b4c930113a33f895", size = 250716, upload-time = "2026-02-03T14:01:48.844Z" },
+    { url = "https://files.pythonhosted.org/packages/44/bb/4ea4eabcce8c4f6235df6e059fbc5db49107b24c4bdffc44aee81aeca5a8/coverage-7.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5b1ad2e0dc672625c44bc4fe34514602a9fd8b10d52ddc414dc585f74453516c", size = 250530, upload-time = "2026-02-03T14:01:50.793Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/4a6c9e6a71367e6f923b27b528448c37f4e959b7e4029330523014691007/coverage-7.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b2beb64c145593a50d90db5c7178f55daeae129123b0d265bdb3cbec83e5194a", size = 252186, upload-time = "2026-02-03T14:01:52.607Z" },
+    { url = "https://files.pythonhosted.org/packages/27/92/e1451ef6390a4f655dc42da35d9971212f7abbbcad0bdb7af4407897eb76/coverage-7.13.3-cp314-cp314-win32.whl", hash = "sha256:3d1aed4f4e837a832df2f3b4f68a690eede0de4560a2dbc214ea0bc55aabcdb4", size = 222253, upload-time = "2026-02-03T14:01:55.071Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/98/78885a861a88de020c32a2693487c37d15a9873372953f0c3c159d575a43/coverage-7.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9f9efbbaf79f935d5fbe3ad814825cbce4f6cdb3054384cb49f0c0f496125fa0", size = 223069, upload-time = "2026-02-03T14:01:56.95Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fb/3784753a48da58a5337972abf7ca58b1fb0f1bda21bc7b4fae992fd28e47/coverage-7.13.3-cp314-cp314-win_arm64.whl", hash = "sha256:31b6e889c53d4e6687ca63706148049494aace140cffece1c4dc6acadb70a7b3", size = 221633, upload-time = "2026-02-03T14:01:58.758Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f9/75b732d9674d32cdbffe801ed5f770786dd1c97eecedef2125b0d25102dc/coverage-7.13.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c5e9787cec750793a19a28df7edd85ac4e49d3fb91721afcdc3b86f6c08d9aa8", size = 220243, upload-time = "2026-02-03T14:02:01.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7e/2868ec95de5a65703e6f0c87407ea822d1feb3619600fbc3c1c4fa986090/coverage-7.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5b86db331c682fd0e4be7098e6acee5e8a293f824d41487c667a93705d415ca", size = 220515, upload-time = "2026-02-03T14:02:02.862Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/eb/9f0d349652fced20bcaea0f67fc5777bd097c92369f267975732f3dc5f45/coverage-7.13.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:edc7754932682d52cf6e7a71806e529ecd5ce660e630e8bd1d37109a2e5f63ba", size = 261874, upload-time = "2026-02-03T14:02:04.727Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a5/6619bc4a6c7b139b16818149a3e74ab2e21599ff9a7b6811b6afde99f8ec/coverage-7.13.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3a16d6398666510a6886f67f43d9537bfd0e13aca299688a19daa84f543122f", size = 264004, upload-time = "2026-02-03T14:02:06.634Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b7/90aa3fc645a50c6f07881fca4fd0ba21e3bfb6ce3a7078424ea3a35c74c9/coverage-7.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:303d38b19626c1981e1bb067a9928236d88eb0e4479b18a74812f05a82071508", size = 266408, upload-time = "2026-02-03T14:02:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/55/08bb2a1e4dcbae384e638f0effef486ba5987b06700e481691891427d879/coverage-7.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:284e06eadfe15ddfee2f4ee56631f164ef897a7d7d5a15bca5f0bb88889fc5ba", size = 260977, upload-time = "2026-02-03T14:02:11.755Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/76/8bd4ae055a42d8fb5dd2230e5cf36ff2e05f85f2427e91b11a27fea52ed7/coverage-7.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d401f0864a1d3198422816878e4e84ca89ec1c1bf166ecc0ae01380a39b888cd", size = 263868, upload-time = "2026-02-03T14:02:13.565Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/ba000560f11e9e32ec03df5aa8477242c2d95b379c99ac9a7b2e7fbacb1a/coverage-7.13.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3f379b02c18a64de78c4ccdddf1c81c2c5ae1956c72dacb9133d7dd7809794ab", size = 261474, upload-time = "2026-02-03T14:02:16.069Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/4de4de8f9ca7af4733bfcf4baa440121b7dbb3856daf8428ce91481ff63b/coverage-7.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7a482f2da9086971efb12daca1d6547007ede3674ea06e16d7663414445c683e", size = 260317, upload-time = "2026-02-03T14:02:17.996Z" },
+    { url = "https://files.pythonhosted.org/packages/05/71/5cd8436e2c21410ff70be81f738c0dddea91bcc3189b1517d26e0102ccb3/coverage-7.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:562136b0d401992118d9b49fbee5454e16f95f85b120a4226a04d816e33fe024", size = 262635, upload-time = "2026-02-03T14:02:20.405Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/2834bb45bdd70b55a33ec354b8b5f6062fc90e5bb787e14385903a979503/coverage-7.13.3-cp314-cp314t-win32.whl", hash = "sha256:ca46e5c3be3b195098dd88711890b8011a9fa4feca942292bb84714ce5eab5d3", size = 223035, upload-time = "2026-02-03T14:02:22.323Z" },
+    { url = "https://files.pythonhosted.org/packages/26/75/f8290f0073c00d9ae14056d2b84ab92dff21d5370e464cb6cb06f52bf580/coverage-7.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:06d316dbb3d9fd44cca05b2dbcfbef22948493d63a1f28e828d43e6cc505fed8", size = 224142, upload-time = "2026-02-03T14:02:24.143Z" },
+    { url = "https://files.pythonhosted.org/packages/03/01/43ac78dfea8946c4a9161bbc034b5549115cb2b56781a4b574927f0d141a/coverage-7.13.3-cp314-cp314t-win_arm64.whl", hash = "sha256:299d66e9218193f9dc6e4880629ed7c4cd23486005166247c283fb98531656c3", size = 222166, upload-time = "2026-02-03T14:02:26.005Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fb/70af542d2d938c778c9373ce253aa4116dbe7c0a5672f78b2b2ae0e1b94b/coverage-7.13.3-py3-none-any.whl", hash = "sha256:90a8af9dba6429b2573199622d72e0ebf024d6276f16abce394ad4d181bb0910", size = 211237, upload-time = "2026-02-03T14:02:27.986Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -282,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "merle"
-version = "0.0.1"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
@@ -295,6 +330,7 @@ dev = [
     { name = "poethepoet" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -302,7 +338,7 @@ dev = [
 requires-dist = [
     { name = "flask", specifier = ">=3.1.0,<3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "zappa", specifier = "==0.61.2" },
+    { name = "zappa", specifier = ">=0.61.2,<0.63" },
 ]
 
 [package.metadata.requires-dev]
@@ -310,6 +346,7 @@ dev = [
     { name = "poethepoet", specifier = ">=0.34.0" },
     { name = "pyright", specifier = ">=1.1.396" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.9.10" },
 ]
 
@@ -413,6 +450,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Single cleanup PR addressing the four out-of-the-box deploy failures filed in #1-#4. Each bullet maps 1:1 to an issue:

- **#1 — PyPI build**: switches the build backend from setuptools to hatchling and bumps `version` to `0.0.3`, so the broken `0.0.2.2` sdist on PyPI can be superseded. `packages = [\"merle\"]` under `tool.hatch.build.targets.wheel` pulls in `merle/templates/` automatically — no more `package_data` format.
- **#2 — Ollama tarball 404**: `merle/templates/Dockerfile.template` now pulls `ollama-linux-amd64.tar.zst` and extracts with `tar --zstd`; `zstd` is added to the `dnf`/`microdnf` install line.
- **#3 — prepare copies consumer's pyproject.toml + zappa pinned**: adds `merle/templates/pyproject.toml.template` — a minimal manifest with a single `merle @ git+https://github.com/zappa/zappa-merle.git` dep — and generates it into the model cache dir instead of copying the consumer's `pyproject.toml`. Dockerfile's `uv sync` gets `--no-install-project` so the stub manifest doesn't need a backend. Zappa pin relaxed to `>=0.61.2,<0.63`.
- **#4 — zappa PATH + authorizer cache**: `merle.managers._subprocess_env_with_venv_bin()` prepends `Path(sys.executable).parent` onto `PATH` for both `zappa deploy` and `zappa undeploy`, so zappa resolves when merle is launched via its fully-qualified venv path. `authorizer.py` now returns `arn:aws:execute-api:region:account:api-id/*/*/*` for both Allow and Deny so API Gateway's token-keyed `result_ttl` cache covers every path under the same token rather than wedging on the first method.

Also includes housekeeping already on the branch: CI Python 3.14, pre-commit ruff bump.

## Test plan

- [x] `uv run poe check` — ruff clean
- [x] `uv run poe typecheck` — pyright clean
- [x] `uv run pytest -v -m \"not docker\"` — 193 passed (non-docker suite), including new coverage for: authorizer wildcard policy, subprocess PATH helper, minimal pyproject generation, Dockerfile template contents
- [x] `uv build` — wheel + sdist build cleanly; `merle/templates/*.template` and `authorizer.py` ship in the wheel
- [ ] End-to-end `merle prepare` → `docker build` → `merle deploy` against a real AWS account (maintainer to verify before PyPI publish)

Refs #1 #2 #3 #4