### PR TITLE
:sparkles: add --topology function-url and /v1/* proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,59 @@ export AWS_DEFAULT_REGION=us-east-1
 
 **Note:** The region must be specified during `prepare` step as it's embedded in the deployment configuration.
 
+### Deployment topology (`--topology`)
+
+merle supports two deployment topologies. Pick one with `--topology` at `prepare` / `deploy` time.
+
+| Topology | Max request duration | Auth layer | When to pick it |
+| --- | --- | --- | --- |
+| `apigw` (default) | **29 seconds** (API Gateway REST integration cap; cannot be raised) | API Gateway custom authorizer Lambda validates `X-API-Key` before the request reaches Lambda | Small models whose warm end-to-end latency is well under 29s (e.g. `tinyllama`, tiny quantised 1B models). |
+| `function-url` | Up to Lambda's configured `timeout_seconds` (15 min max) | Lambda Function URL with `AuthType=NONE`; the Flask app validates `X-API-Key` via a `before_request` hook | Anything that can't finish in 29s on CPU — basically every real-world model, including `schroneko/gemma-2-2b-jpn-it`, `llama3.2`, `mistral`, and larger. |
+
+> **WARNING — 29s ceiling on `apigw`:** API Gateway REST has a hard 29-second integration timeout that AWS does not let you raise. If cold-start + model-load + first-token exceeds 29s the client gets `HTTP 504 "Endpoint request timed out"` even though the Lambda itself finishes the request (visible in CloudWatch). Streaming does not help — API Gateway buffers before flushing. For CPU inference on anything larger than toy models, choose `--topology function-url`.
+
+#### Function URL example
+
+```bash
+# Prepare + deploy with a Function URL (no API Gateway)
+uvx merle prepare --model schroneko/gemma-2-2b-jpn-it --topology function-url
+uvx merle deploy --model schroneko/gemma-2-2b-jpn-it
+
+# Subsequent chat uses the Function URL automatically
+uvx merle chat --model schroneko/gemma-2-2b-jpn-it
+```
+
+Under `function-url`, merle sets `MERLE_REQUIRE_API_KEY=true` on the Lambda. The Flask app in the container enforces `X-API-Key` on **every** route (including `/health` and `/`), matching the behaviour of the API Gateway authorizer in `apigw` mode. The authorizer Lambda and its IAM role are **not** provisioned in `function-url` mode.
+
+To switch an existing deployment between topologies, destroy it first:
+
+```bash
+uvx merle destroy --model {MODEL}
+uvx merle prepare --model {MODEL} --topology function-url
+uvx merle deploy --model {MODEL}
+```
+
+### OpenAI-compatible clients
+
+merle proxies both Ollama's native API (`/api/*`) and Ollama's OpenAI-compatible surface (`/v1/*`). OpenAI SDK users can point at the merle deployment URL directly:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://<function-url-or-apigw-url>/v1",
+    api_key="<the X-API-Key you set at prepare time>",
+    default_headers={"X-API-Key": "<same token>"},
+)
+
+reply = client.chat.completions.create(
+    model="schroneko/gemma-2-2b-jpn-it",
+    messages=[{"role": "user", "content": "こんにちは"}],
+)
+```
+
+Note: the OpenAI SDK sends the token as `Authorization: Bearer ...`, but merle's authorizer and in-app gate read `X-API-Key`. Pass the token in `default_headers` as shown, or set `X-API-Key` on each request.
+
 ### Using uvx (Recommended)
 
 You can run `merle` without installing it using [uvx](https://docs.astral.sh/uv/guides/tools/), which executes the CLI in an isolated environment:

--- a/merle/app.py
+++ b/merle/app.py
@@ -64,6 +64,27 @@ else:
     logger.info("Ollama server initialized successfully")
 
 
+@app.before_request
+def require_api_key() -> tuple[dict[str, str], int] | None:
+    """
+    Enforce X-API-Key on every request when MERLE_REQUIRE_API_KEY is enabled.
+
+    The function-url topology exposes Lambda with AuthType=NONE, so the app itself
+    must validate the token. The apigw topology disables this gate because the
+    API Gateway authorizer already rejects unauthenticated traffic upstream.
+    """
+    if not settings.MERLE_REQUIRE_API_KEY:
+        return None
+    if not settings.API_KEY:
+        logger.error("MERLE_REQUIRE_API_KEY is set but API_KEY is not configured")
+        return {"error": "Server misconfigured"}, HTTPStatus.INTERNAL_SERVER_ERROR
+    provided = request.headers.get("X-API-Key", "")
+    if provided != settings.API_KEY:
+        logger.warning("Rejected request with missing or invalid X-API-Key")
+        return {"error": "Unauthorized"}, HTTPStatus.UNAUTHORIZED
+    return None
+
+
 @app.route("/health", methods=["GET"])
 def health_check() -> tuple[dict[str, Any], int]:
     """Health check endpoint."""
@@ -78,16 +99,41 @@ def health_check() -> tuple[dict[str, Any], int]:
     return {"status": "unhealthy", "error": "Internal error"}, HTTPStatus.SERVICE_UNAVAILABLE
 
 
-@app.route("/api/<path:path>", methods=["GET", "POST", "PUT", "DELETE"])
-def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa: C901, PLR0911, PLR0912, PLR0915
-    """
-    Proxy all /api/* requests to Ollama server.
+def _validate_chat_context_window(data: Any) -> tuple[dict[str, Any], int] | None:  # noqa: ANN401
+    """Reject chat requests whose messages exceed the configured context window."""
+    if not (data and isinstance(data, dict) and "messages" in data):
+        return None
+    messages = data.get("messages", [])
+    if not messages:
+        return None
+    estimated_tokens = estimate_token_count(messages)
+    context_window_size = settings.OLLAMA_MODEL_CONTEXT_WINDOW_SIZE
+    logger.info(
+        f"Chat request validation - estimated tokens: {estimated_tokens}, context window: {context_window_size}"
+    )
+    if estimated_tokens > context_window_size:
+        error_msg = (
+            f"Request exceeds model context window. "
+            f"Estimated tokens: {estimated_tokens}, "
+            f"max context window: {context_window_size}. "
+            f"Please reduce the conversation history or message length."
+        )
+        logger.warning(error_msg)
+        return {
+            "error": error_msg,
+            "estimated_tokens": estimated_tokens,
+        }, HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    return None
 
+
+def _proxy(target_url: str) -> Response | tuple[dict[str, str], int]:  # noqa: C901, PLR0911, PLR0912, PLR0915
+    """
+    Forward the current Flask request to `target_url` on the local Ollama server.
+
+    Shared by /api/* (Ollama-native) and /v1/* (OpenAI-compatible) proxies.
     Supports both streaming and non-streaming responses.
     """
     try:
-        target_url = f"{settings.OLLAMA_URL}/api/{path}"
-
         # Get request data
         data = None
         if request.method in ["POST", "PUT"]:
@@ -101,31 +147,6 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
             key: value for key, value in request.headers.items() if key.lower() not in ["host", "content-length"]
         }
 
-        # Validate context window size for chat requests
-        if path == "chat" and data and isinstance(data, dict) and "messages" in data:
-            messages = data.get("messages", [])
-            if messages:
-                estimated_tokens = estimate_token_count(messages)
-                context_window_size = settings.OLLAMA_MODEL_CONTEXT_WINDOW_SIZE
-
-                logger.info(
-                    f"Chat request validation - estimated tokens: {estimated_tokens}, "
-                    f"context window: {context_window_size}"
-                )
-
-                if estimated_tokens > context_window_size:
-                    error_msg = (
-                        f"Request exceeds model context window. "
-                        f"Estimated tokens: {estimated_tokens}, "
-                        f"max context window: {context_window_size}. "
-                        f"Please reduce the conversation history or message length."
-                    )
-                    logger.warning(error_msg)
-                    return {
-                        "error": error_msg,
-                        "estimated_tokens": estimated_tokens,
-                    }, HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-
         logger.info(f"Proxying {request.method} request to {target_url}")
 
         # Check if client expects streaming response (from request body)
@@ -136,12 +157,10 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
         logger.info(f"Client requested streaming: {is_streaming_request}")
 
         # Use httpx streaming to get chunks as they arrive from Ollama
-        # This ensures we start sending response to API Gateway immediately
         client = httpx.Client(timeout=settings.OLLAMA_REQUEST_TIMEOUT)
 
         try:
             # Make streaming request to Ollama
-            logger.info(f"Creating stream request for {request.method}")
             if request.method == "GET":
                 stream_response = client.stream("GET", target_url, params=params, headers=headers)
             elif request.method == "POST":
@@ -154,12 +173,9 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
                 client.close()
                 return {"error": "Method not allowed"}, HTTPStatus.METHOD_NOT_ALLOWED
 
-            # Enter the streaming context
-            logger.info("Entering streaming context...")
             http_response = stream_response.__enter__()
             logger.info(f"Got response with status {http_response.status_code}")
 
-            # Check if response is streaming (chunked) or if client requested streaming
             content_type = http_response.headers.get("content-type", "")
             should_stream = is_streaming_request or "stream" in content_type or "ndjson" in content_type
 
@@ -168,10 +184,8 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
 
                 def generate():  # noqa: ANN202
                     try:
-                        # Stream chunks as they arrive from Ollama
                         yield from http_response.iter_bytes()
                     finally:
-                        # Cleanup: exit stream context and close client
                         stream_response.__exit__(None, None, None)
                         client.close()
 
@@ -181,7 +195,6 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
                     headers=dict(http_response.headers),
                 )
 
-            # Non-streaming response: read all content then cleanup
             content = http_response.read()
             response_headers = dict(http_response.headers)
             status_code = http_response.status_code
@@ -192,7 +205,6 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
             return Response(content, status=status_code, headers=response_headers)
 
         except Exception:  # noqa: BLE001
-            # Ensure client is closed on error
             with contextlib.suppress(Exception):
                 client.close()
             raise
@@ -208,6 +220,31 @@ def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:  # noqa
         return {"error": "Internal server error"}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+@app.route("/api/<path:path>", methods=["GET", "POST", "PUT", "DELETE"])
+def proxy_to_ollama(path: str) -> Response | tuple[dict[str, str], int]:
+    """Proxy all /api/* requests to Ollama's native API."""
+    if path == "chat" and request.method in ["POST", "PUT"]:
+        rejection = _validate_chat_context_window(request.get_json(silent=True))
+        if rejection is not None:
+            return rejection
+    return _proxy(f"{settings.OLLAMA_URL}/api/{path}")
+
+
+@app.route("/v1/<path:path>", methods=["GET", "POST", "PUT", "DELETE"])
+def proxy_to_ollama_openai(path: str) -> Response | tuple[dict[str, str], int]:
+    """
+    Proxy /v1/* requests to Ollama's OpenAI-compatible surface.
+
+    Lets consumers point the `openai` SDK (or any OpenAI-compatible client) directly
+    at the merle deployment without a client-side adapter.
+    """
+    if path == "chat/completions" and request.method in ["POST", "PUT"]:
+        rejection = _validate_chat_context_window(request.get_json(silent=True))
+        if rejection is not None:
+            return rejection
+    return _proxy(f"{settings.OLLAMA_URL}/v1/{path}")
+
+
 @app.route("/", methods=["GET"])
 def root() -> tuple[dict[str, Any], int]:
     """Root endpoint with service information."""
@@ -217,7 +254,8 @@ def root() -> tuple[dict[str, Any], int]:
         "model": settings.OLLAMA_MODEL,
         "endpoints": {
             "/health": "Health check",
-            "/api/*": "Ollama API (proxied)",
+            "/api/*": "Ollama native API (proxied)",
+            "/v1/*": "OpenAI-compatible API (proxied)",
         },
     }, HTTPStatus.OK
 
@@ -225,7 +263,9 @@ def root() -> tuple[dict[str, Any], int]:
 @app.errorhandler(HTTPStatus.NOT_FOUND)
 def not_found(_error: HTTPException) -> tuple[dict[str, str], int]:
     """Handle 404 errors."""
-    return {"error": "Endpoint not found. Use /api/* for Ollama API."}, HTTPStatus.NOT_FOUND
+    return {
+        "error": "Endpoint not found. Use /api/* for Ollama native API or /v1/* for OpenAI-compatible API.",
+    }, HTTPStatus.NOT_FOUND
 
 
 @app.errorhandler(HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/merle/cli.py
+++ b/merle/cli.py
@@ -20,11 +20,13 @@ from merle.functions import (
 )
 from merle.managers import DeploymentManager
 from merle.settings import (
+    DEFAULT_TOPOLOGY,
     LAMBDA_MEMORY_SIZE_DEFAULT,
     LAMBDA_MEMORY_SIZE_MAX,
     LAMBDA_MEMORY_SIZE_MIN,
     REGION,
     STAGE,
+    VALID_TOPOLOGIES,
     validate_lambda_memory_size,
 )
 
@@ -194,6 +196,24 @@ def handle_prepare_dockerfile(args: argparse.Namespace) -> int:  # noqa: C901, P
                 print(f"Error: {e}", file=sys.stderr)
                 return 1
 
+        # Load existing configuration to check for existing values
+        config = load_config(cache_dir)
+        existing_model_config = config.get("models", {}).get(args.model, {}).get(stage, {})
+        existing_auth_token = existing_model_config.get("auth_token")
+        existing_topology = existing_model_config.get("topology")
+
+        topology = getattr(args, "topology", DEFAULT_TOPOLOGY)
+        if existing_topology and existing_topology != topology:
+            error_msg = (
+                f"Cannot change topology for existing deployment.\n"
+                f"Current topology: {existing_topology}\n"
+                f"Requested topology: {topology}\n"
+                f"To switch topology, first destroy the deployment with: merle destroy --model {args.model}"
+            )
+            logger.error(error_msg)
+            print(f"Error: {error_msg}", file=sys.stderr)
+            return 1
+
         # Create DeploymentManager
         manager = DeploymentManager(
             model_name=args.model,
@@ -201,12 +221,8 @@ def handle_prepare_dockerfile(args: argparse.Namespace) -> int:  # noqa: C901, P
             project_name=get_effective_project_name(args),
             stage=stage,
             region=args.region,
+            topology=topology,
         )
-
-        # Load existing configuration to check for existing values
-        config = load_config(cache_dir)
-        existing_model_config = config.get("models", {}).get(args.model, {}).get(stage, {})
-        existing_auth_token = existing_model_config.get("auth_token")
 
         # Check if zappa_settings.json already exists
         existing_s3_bucket = None
@@ -329,6 +345,13 @@ def handle_deploy(args: argparse.Namespace) -> int:  # noqa: C901, PLR0912
 
         logger.info(f"Deploying model: {model_name}")
 
+        # Resolve topology: CLI flag wins; otherwise fall back to persisted value,
+        # otherwise the default. This lets `deploy` work both when prepare-dockerfile
+        # set the topology earlier and when deploy auto-prepares from scratch.
+        config_preview = load_config(cache_dir)
+        persisted_topology = config_preview.get("models", {}).get(model_name, {}).get(stage, {}).get("topology")
+        topology = getattr(args, "topology", None) or persisted_topology or DEFAULT_TOPOLOGY
+
         # Create DeploymentManager
         manager = DeploymentManager(
             model_name=model_name,
@@ -336,6 +359,7 @@ def handle_deploy(args: argparse.Namespace) -> int:  # noqa: C901, PLR0912
             project_name=get_effective_project_name(args),
             stage=stage,
             region=args.region,
+            topology=topology,
         )
 
         # Check if preparation is needed
@@ -526,6 +550,7 @@ def handle_list(args: argparse.Namespace) -> int:  # noqa: PLR0912, C901
                 cache_dir=cache_dir,
                 project_name=get_effective_project_name(args),
                 stage=stage,
+                topology=model_config.get("topology", DEFAULT_TOPOLOGY),
             )
 
             # Check if deployment files exist
@@ -624,12 +649,19 @@ def handle_destroy(args: argparse.Namespace) -> int:  # noqa: C901
         stage = args.stage
         logger.info(f"Destroying deployment for model: {model_name}, stage: {stage}")
 
+        # Read topology from config so destroy knows whether to clean up the authorizer
+        config = load_config(cache_dir)
+        persisted_topology = (
+            config.get("models", {}).get(model_name, {}).get(stage, {}).get("topology", DEFAULT_TOPOLOGY)
+        )
+
         # Create DeploymentManager
         manager = DeploymentManager(
             model_name=model_name,
             cache_dir=cache_dir,
             project_name=get_effective_project_name(args),
             stage=stage,
+            topology=persisted_topology,
         )
 
         if not manager.is_prepared:
@@ -703,12 +735,20 @@ def handle_chat(args: argparse.Namespace) -> int:
         stage = args.stage
         logger.info(f"Connecting to model: {model_name}, stage: {stage}")
 
+        # Read topology from config so chat resolves the deployment URL correctly
+        # (function-url vs APIGW go through different lookup paths).
+        config_preview = load_config(cache_dir)
+        persisted_topology = (
+            config_preview.get("models", {}).get(model_name, {}).get(stage, {}).get("topology", DEFAULT_TOPOLOGY)
+        )
+
         # Create DeploymentManager
         manager = DeploymentManager(
             model_name=model_name,
             cache_dir=cache_dir,
             project_name=get_effective_project_name(args),
             stage=stage,
+            topology=persisted_topology,
         )
 
         if not manager.is_prepared:
@@ -863,6 +903,16 @@ def main() -> int:
         "--project",
         help="Project name to prefix cache directory (allows multiple projects to share the same base cache)",
     )
+    prepare_parser.add_argument(
+        "--topology",
+        choices=VALID_TOPOLOGIES,
+        default=DEFAULT_TOPOLOGY,
+        help=(
+            f"Deployment topology (default: {DEFAULT_TOPOLOGY}). "
+            f"'apigw' uses API Gateway REST (29s integration timeout). "
+            f"'function-url' uses a Lambda Function URL (15min Lambda timeout; auth in-app via X-API-Key)."
+        ),
+    )
     prepare_parser.set_defaults(func=handle_prepare_dockerfile)
 
     # deploy command
@@ -914,6 +964,16 @@ def main() -> int:
     deploy_parser.add_argument(
         "--project",
         help="Project name to prefix cache directory (allows multiple projects to share the same base cache)",
+    )
+    deploy_parser.add_argument(
+        "--topology",
+        choices=VALID_TOPOLOGIES,
+        default=None,
+        help=(
+            "Deployment topology. If omitted, uses the value persisted from prepare. "
+            "'apigw' (default) uses API Gateway REST (29s integration timeout). "
+            "'function-url' uses a Lambda Function URL (15min Lambda timeout; auth in-app via X-API-Key)."
+        ),
     )
     deploy_parser.set_defaults(func=handle_deploy)
 

--- a/merle/functions.py
+++ b/merle/functions.py
@@ -396,6 +396,7 @@ def update_model_config(  # noqa: C901, PLR0912
     context_window_size: int | None = None,
     use_split: bool | None = None,
     split_config: dict | None = None,
+    topology: str | None = None,
 ) -> None:
     """
     Update the configuration for a specific model-stage combination.
@@ -412,6 +413,7 @@ def update_model_config(  # noqa: C901, PLR0912
         context_window_size: Optional context window size in tokens
         use_split: Optional flag indicating if split model mode is used
         split_config: Optional split model configuration dict
+        topology: Optional deployment topology ('apigw' or 'function-url')
     """
     config = load_config(cache_dir)
     normalized_name = normalize_model_name(model_name)
@@ -444,6 +446,8 @@ def update_model_config(  # noqa: C901, PLR0912
         model_config["use_split"] = use_split
     if split_config is not None:
         model_config["split"] = split_config
+    if topology is not None:
+        model_config["topology"] = topology
 
     save_config(cache_dir, config)
     logger.info(f"Updated configuration for model: {model_name}, stage: {stage}")

--- a/merle/managers.py
+++ b/merle/managers.py
@@ -29,7 +29,13 @@ from merle.functions import (
     update_model_config,
     validate_ollama_model,
 )
-from merle.settings import REGION
+from merle.settings import (
+    DEFAULT_TOPOLOGY,
+    REGION,
+    TOPOLOGY_APIGW,
+    TOPOLOGY_FUNCTION_URL,
+    VALID_TOPOLOGIES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -76,12 +82,17 @@ class DeploymentManager:
         project_name: str,
         stage: str = "dev",
         region: str | None = None,
+        topology: str = DEFAULT_TOPOLOGY,
     ) -> None:
+        if topology not in VALID_TOPOLOGIES:
+            error_msg = f"Invalid topology: {topology}. Must be one of {VALID_TOPOLOGIES}"
+            raise ValueError(error_msg)
         self.model_name = model_name
         self.cache_dir = cache_dir
         self.project_name = project_name
         self.stage = stage
         self.region = region or REGION
+        self.topology = topology
         self._model_cache_dir: Path | None = None
         self._ecr_image_uri: str | None = None
 
@@ -236,6 +247,7 @@ class DeploymentManager:
             context_window_size=context_window_size,
             use_split=use_split,
             split_config=split_metadata,
+            topology=self.topology,
         )
 
         logger.info(f"Successfully prepared deployment files in {self.model_cache_dir}")
@@ -389,7 +401,7 @@ class DeploymentManager:
             logger.info(f"Authorizer Lambda deployed: {response['FunctionArn']}")
             return response["FunctionArn"]
 
-    def _generate_zappa_settings(
+    def _generate_zappa_settings(  # noqa: C901, PLR0912
         self,
         auth_token: str,
         s3_bucket: str,
@@ -402,28 +414,13 @@ class DeploymentManager:
     ) -> None:
         """Generate zappa_settings.json using Zappa's Python API."""
         mode_str = " (split mode)" if use_split else ""
-        logger.info(f"Generating zappa_settings.json for stage '{self.stage}'{mode_str}")
+        logger.info(f"Generating zappa_settings.json for stage '{self.stage}' (topology: {self.topology}){mode_str}")
 
         cli = ZappaCLI()
         settings_dict = cli._generate_settings_dict(stage=self.stage, config_args=[])
 
         sanitized_project = sanitize_for_cloudformation(self.project_name)
         stage_config = settings_dict[self.stage]
-
-        # Configure authorizer - use ARN if provided (for Docker deployments)
-        if authorizer_arn:
-            authorizer_config = {
-                "arn": authorizer_arn,
-                "token_header": "X-API-Key",
-                "result_ttl": 300,
-            }
-        else:
-            # Fallback to function reference (for zip deployments)
-            authorizer_config = {
-                "function": "authorizer.lambda_handler",
-                "token_header": "X-API-Key",
-                "result_ttl": 300,
-            }
 
         # Build environment variables
         models_path = "/tmp/models"  # noqa: S108
@@ -443,6 +440,11 @@ class DeploymentManager:
             env_vars["MERLE_SPLIT_MODEL"] = "true"
             env_vars["OLLAMA_STARTUP_TIMEOUT"] = "300"
 
+        # Function URL topology moves auth into the Flask app; API Gateway's authorizer
+        # Lambda is not in the request path so the app must validate X-API-Key itself.
+        if self.topology == TOPOLOGY_FUNCTION_URL:
+            env_vars["MERLE_REQUIRE_API_KEY"] = "true"
+
         stage_config.update(
             {
                 "app_function": "merle.app.app",
@@ -455,13 +457,53 @@ class DeploymentManager:
                 "ephemeral_storage": {"Size": ephemeral_storage},
                 "keep_warm": False,
                 "keep_warm_expression": "rate(4 minutes)",
-                "authorizer": authorizer_config,
-                "cors": True,
-                "cors_allow_headers": ["Content-Type", "X-API-Key"],
                 "binary_support": False,
                 "tags": tags,
             }
         )
+
+        if self.topology == TOPOLOGY_APIGW:
+            # Configure authorizer - use ARN if provided (for Docker deployments)
+            if authorizer_arn:
+                authorizer_config = {
+                    "arn": authorizer_arn,
+                    "token_header": "X-API-Key",
+                    "result_ttl": 300,
+                }
+            else:
+                # Fallback to function reference (for zip deployments)
+                authorizer_config = {
+                    "function": "authorizer.lambda_handler",
+                    "token_header": "X-API-Key",
+                    "result_ttl": 300,
+                }
+            stage_config.update(
+                {
+                    "authorizer": authorizer_config,
+                    "cors": True,
+                    "cors_allow_headers": ["Content-Type", "X-API-Key"],
+                }
+            )
+        else:
+            # function-url: tell Zappa to skip API Gateway entirely and create a
+            # Lambda Function URL with AuthType=NONE. The app enforces the X-API-Key.
+            stage_config.update(
+                {
+                    "apigateway_enabled": False,
+                    "function_url_enabled": True,
+                    "function_url_config": {
+                        "authorizer": "NONE",
+                        "cors": {
+                            "allowedOrigins": ["*"],
+                            "allowedHeaders": ["Content-Type", "X-API-Key"],
+                            "allowedMethods": ["*"],
+                            "allowCredentials": False,
+                            "exposedResponseHeaders": ["*"],
+                            "maxAge": 0,
+                        },
+                    },
+                }
+            )
 
         if use_split:
             extra_permissions = [
@@ -653,7 +695,7 @@ class DeploymentManager:
 
         logger.info(f"Updated zappa_settings.json with authorizer ARN: {authorizer_arn}")
 
-    def deploy(self, auth_token: str, max_retries: int = 3, retry_delay: int = 15) -> str | None:
+    def deploy(self, auth_token: str, max_retries: int = 3, retry_delay: int = 15) -> str | None:  # noqa: PLR0912
         """
         Deploy to AWS Lambda using Zappa.
 
@@ -687,14 +729,19 @@ class DeploymentManager:
             raise RuntimeError("Docker image URI not found. Run build_and_push_docker_image() first.")
 
         # Deploy authorizer Lambda separately (required for Docker image deployments)
-        # Zappa doesn't automatically deploy the authorizer when using --docker-image-uri
-        logger.info("Deploying authorizer Lambda function...")
-        authorizer_role_arn = self._get_or_create_authorizer_role()
-        authorizer_arn = self._deploy_authorizer_lambda(image_uri, auth_token, authorizer_role_arn)
-        logger.info(f"Authorizer Lambda deployed: {authorizer_arn}")
+        # Zappa doesn't automatically deploy the authorizer when using --docker-image-uri.
+        # Function-URL topology validates X-API-Key in the Flask app, so the authorizer
+        # Lambda is not needed in that mode.
+        if self.topology == TOPOLOGY_APIGW:
+            logger.info("Deploying authorizer Lambda function...")
+            authorizer_role_arn = self._get_or_create_authorizer_role()
+            authorizer_arn = self._deploy_authorizer_lambda(image_uri, auth_token, authorizer_role_arn)
+            logger.info(f"Authorizer Lambda deployed: {authorizer_arn}")
 
-        # Update zappa settings with authorizer ARN
-        self._update_zappa_settings_with_authorizer(authorizer_arn)
+            # Update zappa settings with authorizer ARN
+            self._update_zappa_settings_with_authorizer(authorizer_arn)
+        else:
+            logger.info("Function-URL topology: skipping authorizer Lambda (auth handled in-app)")
 
         # Set environment for deployment; ensure zappa (installed alongside merle)
         # is resolvable even when merle was launched via its fully-qualified venv path.
@@ -770,6 +817,9 @@ class DeploymentManager:
             lambda_name = f"{project_name}-{self.stage}"
             aws_region = stage_config.get("aws_region", "us-east-1")
 
+            if self.topology == TOPOLOGY_FUNCTION_URL:
+                return self._get_function_url(lambda_name, aws_region)
+
             # Check if CloudFormation stack exists
             cf_client = boto3.client("cloudformation", region_name=aws_region)
             try:
@@ -791,6 +841,20 @@ class DeploymentManager:
         except Exception as e:  # noqa: BLE001
             logger.debug(f"Error getting deployment URL from Zappa: {e}")
             return None
+
+    def _get_function_url(self, function_name: str, aws_region: str) -> str | None:
+        """Fetch the Lambda Function URL for a deployed function."""
+        lambda_client = boto3.client("lambda", region_name=aws_region)
+        try:
+            response = lambda_client.list_function_url_configs(FunctionName=function_name, MaxItems=50)
+        except lambda_client.exceptions.ResourceNotFoundException:
+            logger.debug(f"Lambda function '{function_name}' not found")
+            return None
+        configs = response.get("FunctionUrlConfigs", [])
+        if not configs:
+            return None
+        # Trim trailing slash so clients can concatenate /api/... or /v1/... cleanly
+        return configs[0]["FunctionUrl"].rstrip("/")
 
     def destroy(self, skip_confirmation: bool = False) -> bool:
         """
@@ -824,9 +888,10 @@ class DeploymentManager:
         if not zappa_succeeded:
             logger.warning(f"Zappa undeploy returned exit code {result.returncode}")
 
-        # Clean up authorizer Lambda and IAM role
-        self._delete_authorizer_lambda()
-        self._delete_authorizer_role()
+        # Clean up authorizer Lambda and IAM role (only APIGW topology provisions them)
+        if self.topology == TOPOLOGY_APIGW:
+            self._delete_authorizer_lambda()
+            self._delete_authorizer_role()
 
         # Clean up local files
         self._cleanup_local_files()

--- a/merle/settings.py
+++ b/merle/settings.py
@@ -45,6 +45,16 @@ LAMBDA_MEMORY_SIZE_MIN = 128  # MB - AWS Lambda minimum
 LAMBDA_MEMORY_SIZE_MAX = 10240  # MB (10 GB) - AWS Lambda maximum
 LAMBDA_MEMORY_SIZE_DEFAULT = 8192  # MB (8 GB) - Default memory allocation for 7B models
 
+# Deployment Topology
+TOPOLOGY_APIGW = "apigw"
+TOPOLOGY_FUNCTION_URL = "function-url"
+VALID_TOPOLOGIES = (TOPOLOGY_APIGW, TOPOLOGY_FUNCTION_URL)
+DEFAULT_TOPOLOGY = TOPOLOGY_APIGW
+
+# Application-level API key gate (used when Lambda is exposed via Function URL with AuthType=NONE)
+API_KEY = os.getenv("API_KEY")
+MERLE_REQUIRE_API_KEY = os.getenv("MERLE_REQUIRE_API_KEY", "false").lower() == "true"
+
 
 def get_models_path() -> Path:
     """Get the models directory as a Path object."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -273,3 +273,168 @@ class TestAppContextWindowValidation:
         assert response.status_code == 200
         data = json.loads(response.data)
         assert data["service"] == "merle-ollama-proxy"
+        # Root should advertise the OpenAI-compatible surface too
+        assert "/v1/*" in data["endpoints"]
+
+
+class TestV1Proxy:
+    """Tests for the OpenAI-compatible /v1/* proxy route."""
+
+    @pytest.fixture
+    def client(self):
+        """Create Flask test client."""
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            yield client
+
+    @pytest.fixture(autouse=True)
+    def mock_ollama_init(self):
+        """Mock Ollama initialization to avoid errors in tests."""
+        with patch("merle.app.get_or_initialize", return_value=True):
+            yield
+
+    def _mock_httpx(self, status_code: int = 200, body: bytes = b"{}"):
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.read.return_value = body
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__.return_value = mock_response
+        mock_stream.__exit__.return_value = None
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.stream.return_value = mock_stream
+        mock_client_instance.close.return_value = None
+        return mock_client_instance, mock_response
+
+    def test_v1_chat_completions_proxies_to_ollama(self, client: MagicMock):
+        """POST /v1/chat/completions forwards to Ollama's OpenAI surface."""
+        mock_client, _ = self._mock_httpx(body=b'{"id":"chatcmpl-1"}')
+        with (
+            patch("merle.app.httpx.Client", return_value=mock_client),
+            patch("merle.app.settings.OLLAMA_URL", "http://localhost:11434"),
+            patch("merle.app.settings.OLLAMA_MODEL_CONTEXT_WINDOW_SIZE", 2048),
+        ):
+            response = client.post(
+                "/v1/chat/completions",
+                data=json.dumps(
+                    {
+                        "model": "llama2",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "stream": False,
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert response.status_code == 200
+        # Confirm the proxy hit the /v1 surface on Ollama, not /api/*
+        call_args = mock_client.stream.call_args
+        assert call_args.args[1] == "http://localhost:11434/v1/chat/completions"
+
+    def test_v1_chat_completions_enforces_context_window(self, client: MagicMock):
+        """Oversized /v1/chat/completions requests are rejected with 413."""
+        with patch("merle.app.settings.OLLAMA_MODEL_CONTEXT_WINDOW_SIZE", 10):
+            response = client.post(
+                "/v1/chat/completions",
+                data=json.dumps(
+                    {
+                        "model": "llama2",
+                        "messages": [{"role": "user", "content": "a" * 1000}],
+                    }
+                ),
+                content_type="application/json",
+            )
+        assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+        data = json.loads(response.data)
+        assert "exceeds model context window" in data["error"].lower()
+
+    def test_v1_models_proxies_get(self, client: MagicMock):
+        """GET /v1/models forwards to Ollama's OpenAI surface."""
+        mock_client, _ = self._mock_httpx(body=b'{"data":[]}')
+        with (
+            patch("merle.app.httpx.Client", return_value=mock_client),
+            patch("merle.app.settings.OLLAMA_URL", "http://localhost:11434"),
+        ):
+            response = client.get("/v1/models")
+        assert response.status_code == 200
+        call_args = mock_client.stream.call_args
+        assert call_args.args[0] == "GET"
+        assert call_args.args[1] == "http://localhost:11434/v1/models"
+
+    def test_not_found_message_mentions_both_surfaces(self, client: MagicMock):
+        """404 text should point users at both /api/* and /v1/*."""
+        response = client.get("/does-not-exist")
+        assert response.status_code == 404
+        data = json.loads(response.data)
+        assert "/api/*" in data["error"]
+        assert "/v1/*" in data["error"]
+
+
+class TestApiKeyGate:
+    """Tests for the app-level X-API-Key @before_request hook."""
+
+    @pytest.fixture
+    def client(self):
+        """Create Flask test client."""
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            yield client
+
+    @pytest.fixture(autouse=True)
+    def mock_ollama_init(self):
+        """Mock Ollama initialization to avoid errors in tests."""
+        with patch("merle.app.get_or_initialize", return_value=True):
+            yield
+
+    def test_gate_disabled_by_default(self, client: MagicMock):
+        """When MERLE_REQUIRE_API_KEY is false the gate is inert and /health is reachable."""
+        with (
+            patch("merle.app.settings.MERLE_REQUIRE_API_KEY", False),
+            patch("merle.app.httpx.get") as mock_get,
+        ):
+            mock_get.return_value.status_code = 200
+            response = client.get("/health")
+        assert response.status_code == 200
+
+    def test_gate_rejects_missing_key(self, client: MagicMock):
+        """With gate enabled, requests without X-API-Key get 401."""
+        with (
+            patch("merle.app.settings.MERLE_REQUIRE_API_KEY", True),
+            patch("merle.app.settings.API_KEY", "secret-token"),
+        ):
+            response = client.get("/health")
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        data = json.loads(response.data)
+        assert data["error"] == "Unauthorized"
+
+    def test_gate_rejects_wrong_key(self, client: MagicMock):
+        """With gate enabled, requests with a wrong X-API-Key get 401."""
+        with (
+            patch("merle.app.settings.MERLE_REQUIRE_API_KEY", True),
+            patch("merle.app.settings.API_KEY", "secret-token"),
+        ):
+            response = client.get("/health", headers={"X-API-Key": "wrong"})
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    def test_gate_accepts_correct_key(self, client: MagicMock):
+        """With gate enabled, correct X-API-Key lets the request through."""
+        with (
+            patch("merle.app.settings.MERLE_REQUIRE_API_KEY", True),
+            patch("merle.app.settings.API_KEY", "secret-token"),
+            patch("merle.app.httpx.get") as mock_get,
+        ):
+            mock_get.return_value.status_code = 200
+            response = client.get("/health", headers={"X-API-Key": "secret-token"})
+        assert response.status_code == 200
+
+    def test_gate_errors_when_api_key_unset(self, client: MagicMock):
+        """With gate enabled but API_KEY missing, the server signals misconfiguration."""
+        with (
+            patch("merle.app.settings.MERLE_REQUIRE_API_KEY", True),
+            patch("merle.app.settings.API_KEY", None),
+        ):
+            response = client.get("/health", headers={"X-API-Key": "anything"})
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        data = json.loads(response.data)
+        assert data["error"] == "Server misconfigured"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -937,3 +937,102 @@ class TestHandleChat:
         result = handle_chat(args)
 
         assert result == 1
+
+
+class TestTopologyOption:
+    """CLI-level tests for the --topology flag added for issue #5."""
+
+    def test_parser_rejects_unknown_topology(self):
+        """Argparse should reject topology values outside the choices list."""
+        from merle.cli import main  # noqa: PLC0415
+
+        with (
+            patch("sys.argv", ["merle", "prepare", "--model", "llama2", "--topology", "ec2"]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+    @patch("merle.managers.DeploymentManager.prepare")
+    @patch("merle.cli.generate_unique_bucket_name")
+    @patch("merle.cli.get_config_directory")
+    @patch("merle.cli.get_default_project_name")
+    def test_prepare_propagates_topology_to_manager(
+        self,
+        mock_get_default_project: MagicMock,
+        mock_get_config: MagicMock,
+        mock_gen_bucket: MagicMock,
+        mock_prepare: MagicMock,
+        temp_cache_dir: Path,
+    ):
+        """handle_prepare_dockerfile should construct a DeploymentManager with the passed topology."""
+        mock_get_config.return_value = temp_cache_dir
+        mock_gen_bucket.return_value = "zappa-merle-deadbeef"
+        mock_prepare.return_value = temp_cache_dir / "testproject" / "dev" / "llama2"
+        mock_get_default_project.return_value = "testproject"
+
+        args = argparse.Namespace(
+            model="llama2",
+            auth_token="tok",
+            region="us-east-1",
+            cache_dir=None,
+            tags=None,
+            s3_bucket=None,
+            stage="dev",
+            memory_size=8192,
+            project=None,
+            topology="function-url",
+        )
+
+        with patch("merle.cli.DeploymentManager") as mock_manager_cls:
+            instance = MagicMock()
+            instance.is_prepared = False
+            instance.prepare.return_value = mock_prepare.return_value
+            mock_manager_cls.return_value = instance
+            result = handle_prepare_dockerfile(args)
+
+        assert result == 0
+        _, kwargs = mock_manager_cls.call_args
+        assert kwargs["topology"] == "function-url"
+
+    @patch("merle.cli.get_config_directory")
+    @patch("merle.cli.get_default_project_name")
+    def test_prepare_rejects_topology_change_on_existing_deployment(
+        self,
+        mock_get_default_project: MagicMock,
+        mock_get_config: MagicMock,
+        temp_cache_dir: Path,
+    ):
+        """Switching topology on an already-configured deployment must error out."""
+        mock_get_config.return_value = temp_cache_dir
+        mock_get_default_project.return_value = "testproject"
+
+        # Seed config with an existing apigw deployment for this model+stage
+        project_cache = temp_cache_dir / "testproject"
+        project_cache.mkdir(parents=True, exist_ok=True)
+        (project_cache / "config.json").write_text(
+            json.dumps(
+                {
+                    "models": {
+                        "llama2": {
+                            "dev": {"topology": "apigw", "auth_token": "existing"},
+                        }
+                    }
+                }
+            )
+        )
+
+        args = argparse.Namespace(
+            model="llama2",
+            auth_token=None,
+            region="us-east-1",
+            cache_dir=None,
+            tags=None,
+            s3_bucket=None,
+            stage="dev",
+            memory_size=8192,
+            project="testproject",
+            topology="function-url",
+        )
+
+        result = handle_prepare_dockerfile(args)
+        assert result == 1

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -409,3 +409,179 @@ class TestCleanupLocalFiles:
 
         prepared_manager._cleanup_local_files()
         assert not cache_dir.exists()
+
+
+class TestTopology:
+    """Tests for the --topology (apigw / function-url) feature covering issue #5."""
+
+    def test_invalid_topology_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid topology"):
+            DeploymentManager(
+                model_name="llama2",
+                cache_dir=tmp_path,
+                project_name="proj",
+                topology="elb",
+            )
+
+    def test_function_url_manager_exposes_topology(self, tmp_path):
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="proj",
+            topology="function-url",
+        )
+        assert mgr.topology == "function-url"
+
+    @patch("merle.managers.ZappaCLI")
+    def test_apigw_settings_include_authorizer_and_omit_function_url(self, mock_zappa_cli_cls, tmp_path):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="proj",
+            stage="dev",
+            topology="apigw",
+        )
+        mgr.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        mgr._generate_zappa_settings(auth_token="tok", s3_bucket="bkt", tags={})
+
+        settings = json.loads(mgr.zappa_settings_path.read_text())
+        stage = settings["dev"]
+        assert "authorizer" in stage
+        assert stage["cors"] is True
+        assert "X-API-Key" in stage["cors_allow_headers"]
+        assert "apigateway_enabled" not in stage  # default: APIGW stays enabled
+        assert "function_url_enabled" not in stage
+        assert "MERLE_REQUIRE_API_KEY" not in stage["environment_variables"]
+
+    @patch("merle.managers.ZappaCLI")
+    def test_function_url_settings_suppress_apigw_and_enable_function_url(self, mock_zappa_cli_cls, tmp_path):
+        mock_cli = MagicMock()
+        mock_cli._generate_settings_dict.return_value = {"dev": {}}
+        mock_zappa_cli_cls.return_value = mock_cli
+
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="proj",
+            stage="dev",
+            topology="function-url",
+        )
+        mgr.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        mgr._generate_zappa_settings(auth_token="tok", s3_bucket="bkt", tags={})
+
+        settings = json.loads(mgr.zappa_settings_path.read_text())
+        stage = settings["dev"]
+        assert stage["apigateway_enabled"] is False
+        assert stage["function_url_enabled"] is True
+        assert stage["function_url_config"]["authorizer"] == "NONE"
+        # App-level gate is what keeps the Function URL safe
+        assert stage["environment_variables"]["MERLE_REQUIRE_API_KEY"] == "true"
+        # Authorizer / CORS APIGW bits must not leak into function-url settings
+        assert "authorizer" not in stage
+        assert "cors" not in stage
+        assert "cors_allow_headers" not in stage
+
+    @patch("merle.managers.subprocess.run")
+    @patch("merle.managers.boto3.client")
+    @patch.object(DeploymentManager, "_get_or_create_authorizer_role")
+    @patch.object(DeploymentManager, "_deploy_authorizer_lambda")
+    @patch.object(DeploymentManager, "_update_zappa_settings_with_authorizer")
+    @patch.object(
+        DeploymentManager,
+        "get_deployment_url",
+        return_value="https://abcd.lambda-url.us-east-1.on.aws",
+    )
+    @patch("merle.managers.update_model_config")
+    def test_function_url_deploy_skips_authorizer_wiring(
+        self,
+        mock_update_config,
+        mock_get_url,
+        mock_update_auth_settings,
+        mock_deploy_auth,
+        mock_create_role,
+        mock_boto,
+        mock_run,
+        tmp_path,
+    ):
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="proj",
+            stage="dev",
+            topology="function-url",
+        )
+        mgr.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        settings = {
+            "dev": {
+                "project_name": "proj",
+                "aws_region": "us-east-1",
+                "docker_image_uri": "123.dkr.ecr.us-east-1.amazonaws.com/merle-llama2:latest",
+            }
+        }
+        mgr.zappa_settings_path.write_text(json.dumps(settings))
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        url = mgr.deploy(auth_token="tok")
+
+        assert url == "https://abcd.lambda-url.us-east-1.on.aws"
+        mock_create_role.assert_not_called()
+        mock_deploy_auth.assert_not_called()
+        mock_update_auth_settings.assert_not_called()
+
+    @patch("merle.managers.subprocess.run")
+    @patch.object(DeploymentManager, "_delete_authorizer_lambda")
+    @patch.object(DeploymentManager, "_delete_authorizer_role")
+    @patch.object(DeploymentManager, "_cleanup_local_files")
+    def test_function_url_destroy_skips_authorizer_cleanup(
+        self,
+        mock_cleanup,
+        mock_del_role,
+        mock_del_lambda,
+        mock_run,
+        tmp_path,
+    ):
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="proj",
+            stage="dev",
+            topology="function-url",
+        )
+        mgr.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        mgr.zappa_settings_path.write_text(json.dumps({"dev": {}}))
+        mock_run.return_value = MagicMock(returncode=0)
+
+        assert mgr.destroy() is True
+        mock_del_lambda.assert_not_called()
+        mock_del_role.assert_not_called()
+        mock_cleanup.assert_called_once()
+
+    @patch("merle.managers.boto3.client")
+    def test_function_url_get_deployment_url_reads_from_lambda(self, mock_boto_client, tmp_path):
+        lambda_client = MagicMock()
+        lambda_client.exceptions = MagicMock()
+        lambda_client.exceptions.ResourceNotFoundException = type("NotFound", (Exception,), {})
+        lambda_client.list_function_url_configs.return_value = {
+            "FunctionUrlConfigs": [
+                {"FunctionUrl": "https://abcd.lambda-url.us-east-1.on.aws/"},
+            ]
+        }
+        mock_boto_client.return_value = lambda_client
+
+        mgr = DeploymentManager(
+            model_name="llama2",
+            cache_dir=tmp_path,
+            project_name="proj",
+            stage="dev",
+            topology="function-url",
+        )
+        mgr.model_cache_dir.mkdir(parents=True, exist_ok=True)
+        mgr.zappa_settings_path.write_text(json.dumps({"dev": {"project_name": "proj", "aws_region": "us-east-1"}}))
+
+        url = mgr.get_deployment_url()
+        assert url == "https://abcd.lambda-url.us-east-1.on.aws"
+        lambda_client.list_function_url_configs.assert_called_once_with(FunctionName="proj-dev", MaxItems=50)


### PR DESCRIPTION
Refs #5.

## Summary

Two changes that together make merle usable for real inference from existing codebases:

- **Part A — `--topology function-url`**: optional Lambda Function URL topology that bypasses API Gateway REST's hard 29-second integration timeout. Auth stays as `X-API-Key`, validated in the Flask app via a `@before_request` hook (activated by `MERLE_REQUIRE_API_KEY=true`). No IAM authorizer required — lightweight, per the reporter's feedback on the issue.
- **Part B — `/v1/*` proxy**: new route forwards to Ollama's OpenAI-compatible surface (`/v1/chat/completions`, `/v1/completions`, `/v1/models`, `/v1/embeddings`, ...), so consumers using the `openai` SDK can hit the merle deployment URL without a client-side adapter.

Default topology remains `apigw` — this PR is backwards-compatible for existing deployments.

## How the topologies differ

| | `apigw` (default) | `function-url` |
| --- | --- | --- |
| Max request duration | 29s (APIGW REST cap) | 15min (Lambda cap) |
| Auth | APIGW authorizer Lambda | App-level `X-API-Key` gate |
| `zappa_settings` | unchanged | `apigateway_enabled: false`, `function_url_enabled: true`, `function_url_config.authorizer: NONE` |
| Extra resources | authorizer Lambda + IAM role | none |

Zappa 0.61.2 natively supports both flags — no upstream Zappa change was needed.

## Key implementation points

- `merle/managers.py`: `_generate_zappa_settings` branches on topology; `deploy`/`destroy` skip authorizer wiring under `function-url`. New `_get_function_url()` resolves the deployed URL via `list_function_url_configs`.
- `merle/app.py`: factored the proxy body into a `_proxy(target_url)` helper shared by `/api/*` and `/v1/*`. Context-window validation now fires for both `/api/chat` and `/v1/chat/completions`.
- `merle/cli.py`: `--topology` on `prepare`/`deploy`. Topology is persisted in `config.json` so `list`/`destroy`/`chat` resolve the correct URL. Changing topology on an existing deployment is rejected (destroy first).
- `README.md`: topology matrix, 29s ceiling warning, OpenAI SDK quickstart.

## Test plan

- [x] `uv run poe check` — ruff clean
- [x] `uv run poe typecheck` — pyright clean
- [x] `uv run poe test` — 232 passed, 0 failed, 65% coverage (up from 212 before this PR; no Docker tests run)
- [ ] Manual: `uvx merle prepare --model <X> --topology function-url` → `uvx merle deploy --model <X>` → verify Function URL returned, hit `/api/chat` and `/v1/chat/completions` with `X-API-Key`
- [ ] Manual: existing `apigw` deployments continue to work unchanged (smoke test on a deployed model)
- [ ] Manual: `uvx merle destroy --model <X>` on a `function-url` deployment cleans up without touching the (non-existent) authorizer

## Notes

- `InvokeMode` is left at AWS's default (`BUFFERED`). Zappa 0.61.2 doesn't expose `RESPONSE_STREAM`, and our WSGI/Flask handler doesn't support streaming responses from a Lambda anyway. `BUFFERED` matches the reporter's tested config (warm JPN inference ~3–7s end-to-end).
- Per repo convention, this PR does **not** close #5 — leaving that to the maintainer after manual verification.